### PR TITLE
Function to determine if a set is performed or not

### DIFF
--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -1551,7 +1551,7 @@ func TestProcessWithAlwaysSet(t *testing.T) {
 		t.Fatalf("Failed to process %#v error: %s", q, err.Error())
 	}
 
-	if 99 != q.Value {
+	if q.Value != 99 {
 		t.Fatalf("Expected 99 not %d in Quark.Value", q.Value)
 	}
 }


### PR DESCRIPTION
Hi, and thanks for a great library!

I've got a use-case where I load stuff from a _JSON_ file, AWS parameter store & AWS secrets manager and then applies environment variables. 

This is a override chain where the _JSON_ file is static default configuration and secrets and other IAM handled parameters are from AWS services. Lastly sometimes the _DevOps_ need to do a parameter override directly at the lambda level on a environment variable.

Since current implementation only overrides when ef.IsZero() I needed to have the ability to choose if this is the case or always try to override.

Therefore I did this PR that allows a custom `Decider` function to be set.

```go
	err := ProcessWith(
		context.Background(),
		&q,
		OsLookuper(),
		func(ctx context.Context, value reflect.Value) bool {
			return true // always set
		},
	)
```

I've added a `DefaultDeciderFunction` to be used internally on `Process` and if just the _standard_ behaviour in `ProcessWith`.

```go
// This is the default behaviour
var DefaultDeciderFunc = func(ctx context.Context, value reflect.Value) bool {
	return value.IsZero()
}

// Process uses the DefaultDeciderFunc
func Process(ctx context.Context, i interface{}) error {
	return ProcessWith(ctx, i, OsLookuper(), DefaultDeciderFunc)
}

// In unit test I've replaced with DefaultDeciderFunc
if err := ProcessWith(ctx, tc.input, tc.lookuper, DefaultDeciderFunc, tc.mutators...); err != nil {
  // ...
}
```

Cheers,
 Mario