### PR TITLE
Fix error message of missing value with prefix

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -399,6 +399,10 @@ func lookup(key string, opts *options, l Lookuper) (string, error) {
 	val, ok := l.Lookup(key)
 	if !ok {
 		if opts.Required {
+			if pl, ok := l.(*prefixLookuper); ok {
+				key = pl.prefix + key
+			}
+
 			return "", fmt.Errorf("%w: %s", ErrMissingRequired, key)
 		}
 

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -98,7 +98,7 @@ type VCR struct {
 
 type Remote struct {
 	Button *Button `env:",prefix=REMOTE_BUTTON_"`
-	Name   string  `env:"REMOTE_NAME"`
+	Name   string  `env:"REMOTE_NAME,required"`
 	Power  bool    `env:"POWER"`
 }
 
@@ -1484,6 +1484,16 @@ func TestProcessWith(t *testing.T) {
 					base64.StdEncoding.EncodeToString([]byte("foo")),
 					base64.StdEncoding.EncodeToString([]byte("bar")),
 				),
+			}),
+		},
+		{
+			// https://github.com/sethvargo/go-envconfig/issues/28
+			name:   "embedded_prefixes/error-keys",
+			input:  &VCR{},
+			errMsg: "VCR_REMOTE_NAME",
+			lookuper: MapLookuper(map[string]string{
+				"NAME":                   "vcr",
+				"VCR_REMOTE_BUTTON_NAME": "button",
 			}),
 		},
 	}


### PR DESCRIPTION
When using a prefix the error message for a missing required value
was incorrectly showing the key in the error message without the
prefix.

Fixes #28