### PR TITLE
Correct the mutator extension example

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ type Config struct {
 }
 
 func resolveSecretFunc(ctx context.Context, key, value string) (string, error) {
-  if strings.HasPrefix(key, "secret://") {
+  if strings.HasPrefix(value, "secret://") {
     return secretmanager.Resolve(ctx, value) // example
   }
   return value, nil

--- a/envconfig.go
+++ b/envconfig.go
@@ -54,7 +54,7 @@
 //     }
 //
 //     func resolveSecretFunc(ctx context.Context, key, value string) (string, error) {
-//         if strings.HasPrefix(key, "secret://") {
+//         if strings.HasPrefix(value, "secret://") {
 //             return secretmanager.Resolve(ctx, value) // example
 //         }
 //         return value, nil


### PR DESCRIPTION
The environment variable does not include a prefix so its value should
be checked for it.

Assume the intention is that the environment variable's value should be
similar to the Berglas reference syntax.