### PR TITLE
The Decoder interface, if used, is prioritary over other decoders (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ export APP_MYVAR="foo"
 ## Extension
 
 All built-in types are supported except Func and Chan. If you need to define a
-custom decoder, implement `Decoder`:
+custom decoder, implement the `Decoder` interface:
 
 ```go
 type MyStruct struct {
@@ -239,6 +239,8 @@ func (v *MyStruct) EnvDecode(val string) error {
   v.field = fmt.Sprintf("PREFIX-%s", val)
   return nil
 }
+
+var _ envconfig.Decoder = (*MyStruct)(nil) // interface check
 ```
 
 If you need to modify environment variable values before processing, you can

--- a/envconfig.go
+++ b/envconfig.go
@@ -447,38 +447,41 @@ func processAsDecoder(v string, ef reflect.Value) (bool, error) {
 	if ef.CanInterface() {
 		iface := ef.Interface()
 
+		// If a developer chooses to implement the Decoder interface on a type,
+		// never attempt to use other decoders in case of failure. EnvDecode's
+		// decoding logic is "the right one", and the error returned (if any)
+		// is the most specific we can get.
 		if dec, ok := iface.(Decoder); ok {
 			imp = true
-			if err = dec.EnvDecode(v); err == nil {
-				return true, nil
-			}
+			err = dec.EnvDecode(v)
+			return imp, err
 		}
 
 		if tu, ok := iface.(encoding.BinaryUnmarshaler); ok {
 			imp = true
 			if err = tu.UnmarshalBinary([]byte(v)); err == nil {
-				return true, nil
+				return imp, nil
 			}
 		}
 
 		if tu, ok := iface.(gob.GobDecoder); ok {
 			imp = true
 			if err = tu.GobDecode([]byte(v)); err == nil {
-				return true, nil
+				return imp, nil
 			}
 		}
 
 		if tu, ok := iface.(json.Unmarshaler); ok {
 			imp = true
 			if err = tu.UnmarshalJSON([]byte(v)); err == nil {
-				return true, nil
+				return imp, nil
 			}
 		}
 
 		if tu, ok := iface.(encoding.TextUnmarshaler); ok {
 			imp = true
 			if err = tu.UnmarshalText([]byte(v)); err == nil {
-				return true, nil
+				return imp, nil
 			}
 		}
 	}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -16,7 +16,10 @@ package envconfig
 
 import (
 	"context"
+	"encoding"
 	"encoding/base64"
+	"encoding/gob"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -39,15 +42,37 @@ func (c *CustomType) EnvDecode(val string) error {
 	return nil
 }
 
-var _ Decoder = (*CustomTypeError)(nil)
+var (
+	_ Decoder                    = (*CustomTypeError)(nil)
+	_ encoding.BinaryUnmarshaler = (*CustomTypeError)(nil)
+	_ gob.GobDecoder             = (*CustomTypeError)(nil)
+	_ json.Unmarshaler           = (*CustomTypeError)(nil)
+	_ encoding.TextUnmarshaler   = (*CustomTypeError)(nil)
+)
 
-// CustomTypeError returns an error on the custom decoder.
+// CustomTypeError returns a "broken" error via the custom decoder.
 type CustomTypeError struct {
 	Field string
 }
 
 func (c *CustomTypeError) EnvDecode(val string) error {
 	return fmt.Errorf("broken")
+}
+
+func (c *CustomTypeError) UnmarshalBinary(data []byte) error {
+	return fmt.Errorf("must never be returned")
+}
+
+func (c *CustomTypeError) GobDecode(data []byte) error {
+	return fmt.Errorf("must never be returned")
+}
+
+func (c *CustomTypeError) UnmarshalJSON(data []byte) error {
+	return fmt.Errorf("must never be returned")
+}
+
+func (c *CustomTypeError) UnmarshalText(text []byte) error {
+	return fmt.Errorf("must never be returned")
 }
 
 // valueMutatorFunc is used for testing mutators.


### PR DESCRIPTION
This is a fix proposal for https://github.com/sethvargo/go-envconfig/issues/38.