### PR TITLE
add overwrite struct tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ type DatabaseConfig struct {
 
 Use the `env` struct tag to define configuration.
 
+### Overwrite
+
+If overwrite is set, the value will be overwritten if there is an
+environment variable match regardless if the value is non-zero.
+
+```go
+type MyStruct struct {
+  Port int `env:"PORT,overwrite"`
+}
+```
+
 ### Required
 
 If a field is required, processing will error if the environment variable is
@@ -298,9 +309,9 @@ major behavioral differences:
 -   Adds support for specifying a custom lookup function (such as a map), which
     is useful for testing.
 
--   Only populates fields if they contain zero or nil values. This means you can
-    pre-initialize a struct and any pre-populated fields will not be overwritten
-    during processing.
+-   Only populates fields if they contain zero or nil values if `overwrite` is unset.
+    This means you can pre-initialize a struct and any pre-populated fields will not
+    be overwritten during processing.
 
 -   Support for interpolation. The default value for a field can be the value of
     another field.

--- a/envconfig.go
+++ b/envconfig.go
@@ -83,10 +83,10 @@ import (
 const (
 	envTag = "env"
 
-	optReplace  = "replace"
-	optRequired = "required"
-	optDefault  = "default="
-	optPrefix   = "prefix="
+	optOverwrite = "overwrite"
+	optRequired  = "required"
+	optDefault   = "default="
+	optPrefix    = "prefix="
 )
 
 var envvarNameRe = regexp.MustCompile(`\A[a-zA-Z_][a-zA-Z0-9_]*\z`)
@@ -213,10 +213,10 @@ type MutatorFunc func(ctx context.Context, k, v string) (string, error)
 
 // options are internal options for decoding.
 type options struct {
-	Default  string
-	Required bool
-	Replace  bool
-	Prefix   string
+	Default   string
+	Overwrite bool
+	Required  bool
+	Prefix    string
 }
 
 // Process processes the struct using the environment. See ProcessWith for a
@@ -327,8 +327,8 @@ func ProcessWith(ctx context.Context, i interface{}, l Lookuper, fns ...MutatorF
 			continue
 		}
 
-		// The field already has a non-zero value and replace is false, do not overwrite.
-		if !ef.IsZero() && !opts.Replace {
+		// The field already has a non-zero value and overwrite is false, do not overwrite.
+		if !ef.IsZero() && !opts.Overwrite {
 			continue
 		}
 
@@ -373,8 +373,8 @@ LOOP:
 	for i, o := range tagOpts {
 		o = strings.TrimSpace(o)
 		switch {
-		case o == optReplace:
-			opts.Replace = true
+		case o == optOverwrite:
+			opts.Overwrite = true
 		case o == optRequired:
 			opts.Required = true
 		case strings.HasPrefix(o, optPrefix):

--- a/envconfig.go
+++ b/envconfig.go
@@ -83,6 +83,7 @@ import (
 const (
 	envTag = "env"
 
+	optReplace  = "replace"
 	optRequired = "required"
 	optDefault  = "default="
 	optPrefix   = "prefix="
@@ -214,6 +215,7 @@ type MutatorFunc func(ctx context.Context, k, v string) (string, error)
 type options struct {
 	Default  string
 	Required bool
+	Replace  bool
 	Prefix   string
 }
 
@@ -325,8 +327,8 @@ func ProcessWith(ctx context.Context, i interface{}, l Lookuper, fns ...MutatorF
 			continue
 		}
 
-		// The field already has a non-zero value, do not overwrite.
-		if !ef.IsZero() {
+		// The field already has a non-zero value and replace is false, do not overwrite.
+		if !ef.IsZero() && !opts.Replace {
 			continue
 		}
 
@@ -371,6 +373,8 @@ LOOP:
 	for i, o := range tagOpts {
 		o = strings.TrimSpace(o)
 		switch {
+		case o == optReplace:
+			opts.Replace = true
 		case o == optRequired:
 			opts.Required = true
 		case strings.HasPrefix(o, optPrefix):

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -730,6 +730,40 @@ func TestProcessWith(t *testing.T) {
 			err: ErrPrivateField,
 		},
 
+		// Overwrite
+		{
+			name: "overwrite/present",
+			input: &struct {
+				Field string `env:"FIELD,overwrite"`
+			}{
+				Field: "hello world",
+			},
+			exp: &struct {
+				Field string `env:"FIELD,overwrite"`
+			}{
+				Field: "foo",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "foo",
+			}),
+		},
+		{
+			name: "overwrite/present_space",
+			input: &struct {
+				Field string `env:"FIELD, overwrite"`
+			}{
+				Field: "hello world",
+			},
+			exp: &struct {
+				Field string `env:"FIELD, overwrite"`
+			}{
+				Field: "foo",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "foo",
+			}),
+		},
+
 		// Required
 		{
 			name: "required/present",


### PR DESCRIPTION
Allows items to be replaced when the value is a non-zero entry. Useful for using it with a semi-populated struct before hand.