### PR TITLE
Add notempty struct tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ type MyStruct struct {
 
 It is invalid to have a field as both `required` and `default`.
 
+### Not Empty
+
+If notempty is set, processing will error if the environment variable is
+unset or empty.
+
+```go
+type MyStruct struct {
+  Port int `env:"PORT,notempty"`
+}
+```
+
+It is invalid to have a field as both `notempty` and `default`.
+
 ### Default
 
 If an environment variable is not set, the field will be set to the default

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -826,6 +826,88 @@ func TestProcessWith(t *testing.T) {
 			err:      ErrRequiredAndDefault,
 		},
 
+		// Not Empty
+		{
+			name: "notempty/present",
+			input: &struct {
+				Field string `env:"FIELD,notempty"`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,notempty"`
+			}{
+				Field: "foo",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "foo",
+			}),
+		},
+		{
+			name: "notempty/present_space",
+			input: &struct {
+				Field string `env:"FIELD, notempty"`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD, notempty"`
+			}{
+				Field: "foo",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "foo",
+			}),
+		},
+		{
+			name: "notempty/missing",
+			input: &struct {
+				Field string `env:"FIELD,notempty"`
+			}{},
+			lookuper: MapLookuper(map[string]string{}),
+			err:      ErrMissingRequired,
+		},
+		{
+			name: "notempty/missing_space",
+			input: &struct {
+				Field string `env:"FIELD, notempty"`
+			}{},
+			lookuper: MapLookuper(map[string]string{}),
+			err:      ErrMissingRequired,
+		},
+		{
+			name: "notempty/empty",
+			input: &struct {
+				Field string `env:"FIELD,notempty"`
+			}{},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "",
+			}),
+			err: ErrEmpty,
+		},
+		{
+			name: "notempty/empty_space",
+			input: &struct {
+				Field string `env:"FIELD, notempty"`
+			}{},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "",
+			}),
+			err: ErrEmpty,
+		},
+		{
+			name: "notempty/default",
+			input: &struct {
+				Field string `env:"FIELD,notempty,default=foo"`
+			}{},
+			lookuper: MapLookuper(map[string]string{}),
+			err:      ErrRequiredAndDefault,
+		},
+		{
+			name: "notempty/default_space",
+			input: &struct {
+				Field string `env:"FIELD, notempty, default=foo"`
+			}{},
+			lookuper: MapLookuper(map[string]string{}),
+			err:      ErrRequiredAndDefault,
+		},
+
 		// Default
 		{
 			name: "default/missing",


### PR DESCRIPTION
Currently there is no _easy_ way of knowing if a environment variable is set with an empty value except for checking the value yourself. 

In certain workflows like for example when using docker-compose with variable substituion this can be a problem.
In this case a missing system variable is replaced by an empty string. The resulting container sees a set but empty variable. Therefore the `required` keyword does not result in an error and is useless.

`notempty` uses `required` and errors on a _empty_ variable with message "empty value" 