### PR TITLE
Custom key value separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,22 @@ type Server2 struct {
 
 It is invalid to specify a prefix on non-struct fields.
 
+### Separator
+
+By default when parsing maps, `:` is used as key-value separator.
+You can define your own custom separator using `separator`
+
+```go
+type MyStruct struct {
+  MyVar map[string]string `env:"MYVAR,separator=-"`
+}
+```
+
+```bash
+export MYVAR="client-abcd::1/128,backend-abcd::2/128"
+# map[string]string{"client":"abcd::1/128", "backend":"abcd::2/128"}
+```
+
 ## Complex Types
 
 ### Durations

--- a/envconfig.go
+++ b/envconfig.go
@@ -88,6 +88,7 @@ const (
 	optDefault   = "default="
 	optPrefix    = "prefix="
 	optNoInit    = "noinit"
+	optSeparator = "separator="
 )
 
 var envvarNameRe = regexp.MustCompile(`\A[a-zA-Z_][a-zA-Z0-9_]*\z`)
@@ -220,6 +221,7 @@ type options struct {
 	Required  bool
 	Prefix    string
 	NoInit    bool
+  Separator string
 }
 
 // Process processes the struct using the environment. See ProcessWith for a
@@ -376,8 +378,13 @@ func ProcessWith(ctx context.Context, i interface{}, l Lookuper, fns ...MutatorF
 			}
 		}
 
+    // If Separator is not defined set it to ":"
+    if opts.Separator == "" {
+      opts.Separator = ":"
+    }
+
 		// Set value.
-		if err := processField(val, ef); err != nil {
+		if err := processField(val, ef, opts.Separator); err != nil {
 			return fmt.Errorf("%s(%q): %w", tf.Name, val, err)
 		}
 	}
@@ -409,6 +416,8 @@ LOOP:
 			opts.NoInit = true
 		case strings.HasPrefix(o, optPrefix):
 			opts.Prefix = strings.TrimPrefix(o, optPrefix)
+		case strings.HasPrefix(o, optSeparator):
+			opts.Separator = strings.TrimPrefix(o, optSeparator)
 		case strings.HasPrefix(o, optDefault):
 			// If a default value was given, assume everything after is the provided
 			// value, including comma-seprated items.
@@ -523,7 +532,7 @@ func processAsDecoder(v string, ef reflect.Value) (bool, error) {
 	return imp, err
 }
 
-func processField(v string, ef reflect.Value) error {
+func processField(v string, ef reflect.Value, separator string) error {
 	// Handle pointers and uninitialized pointers.
 	for ef.Type().Kind() == reflect.Ptr {
 		if ef.IsNil() {
@@ -599,19 +608,19 @@ func processField(v string, ef reflect.Value) error {
 		vals := strings.Split(v, ",")
 		mp := reflect.MakeMapWithSize(tf, len(vals))
 		for _, val := range vals {
-			pair := strings.SplitN(val, ":", 2)
+			pair := strings.SplitN(val, separator, 2)
 			if len(pair) < 2 {
 				return fmt.Errorf("%s: %w", val, ErrInvalidMapItem)
 			}
 			mKey, mVal := strings.TrimSpace(pair[0]), strings.TrimSpace(pair[1])
 
 			k := reflect.New(tf.Key()).Elem()
-			if err := processField(mKey, k); err != nil {
+			if err := processField(mKey, k, separator); err != nil {
 				return fmt.Errorf("%s: %w", mKey, err)
 			}
 
 			v := reflect.New(tf.Elem()).Elem()
-			if err := processField(mVal, v); err != nil {
+			if err := processField(mVal, v, separator); err != nil {
 				return fmt.Errorf("%s: %w", mVal, err)
 			}
 
@@ -629,7 +638,7 @@ func processField(v string, ef reflect.Value) error {
 			s := reflect.MakeSlice(tf, len(vals), len(vals))
 			for i, val := range vals {
 				val = strings.TrimSpace(val)
-				if err := processField(val, s.Index(i)); err != nil {
+				if err := processField(val, s.Index(i), separator); err != nil {
 					return fmt.Errorf("%s: %w", val, err)
 				}
 			}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -644,6 +644,35 @@ func TestProcessWith(t *testing.T) {
 			}),
 			errMsg: "invalid syntax",
 		},
+		{
+			name: "map/separator",
+			input: &struct {
+				Field map[string]string `env:"FIELD,separator=#"`
+			}{},
+			exp: &struct {
+				Field map[string]string `env:"FIELD,separator=#"`
+			}{
+				Field: map[string]string{"foo": "bar"},
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "foo#bar",
+			}),
+		},
+		{
+			name: "map/separator_error",
+			input: &struct {
+				Field map[string]string `env:"FIELD,separator=#"`
+			}{},
+			exp: &struct {
+				Field map[string]string `env:"FIELD,separator=#"`
+			}{
+				Field: map[string]string{"foo": "bar"},
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "foo:bar",
+			}),
+			errMsg: "invalid map item",
+		},
 
 		// Slices
 		{


### PR DESCRIPTION
## Motivation

Closes #46 

By default when parsing maps, `:` is used as key-value separator.
This PR adds the functionality to define custom separator 

## Changes Made

- Added `optSeparator = "separator="` in `options` for reading separator's value from the tags.
- Added `separator string` in the arguments of `processField`  for incorporating separator while processing the fields.

## Usage

```go
type MyStruct struct {
  MyVar map[string]string `env:"MYVAR,separator=-"`
}
```

```bash
export MYVAR="client-abcd::1/128,backend-abcd::2/128"
# map[string]string{"client":"abcd::1/128", "backend":"abcd::2/128"}
```

