### PR TITLE
Custom element delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,22 @@ type Server2 struct {
 
 It is invalid to specify a prefix on non-struct fields.
 
+### Delimiter
+
+By default when parsing maps and slices, `,` is used as element delimiter.
+You can define your own custom delimiter using `delimiter`
+
+```go
+type MyStruct struct {
+  MyVar map[string]string `env:"MYVAR,delimiter=;"`
+}
+```
+
+```bash
+export MYVAR="a:1;b:2"
+# map[string]string{"a":"1", "b":"2"}
+```
+
 ## Complex Types
 
 ### Durations

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -644,6 +644,34 @@ func TestProcessWith(t *testing.T) {
 			}),
 			errMsg: "invalid syntax",
 		},
+		{
+			name: "map/delimiter_wrong",
+			input: &struct {
+				Field map[string]string `env:"FIELD,delimiter=;"`
+			}{},
+			exp: &struct {
+				Field map[string]string `env:"FIELD,delimiter=;"`
+			}{
+				Field: map[string]string{"foo": "1,bar:2"},
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "foo:1,bar:2",
+			}),
+		},
+		{
+			name: "map/delimiter",
+			input: &struct {
+				Field map[string]string `env:"FIELD,delimiter=;"`
+			}{},
+			exp: &struct {
+				Field map[string]string `env:"FIELD,delimiter=;"`
+			}{
+				Field: map[string]string{"foo": "1", "bar" : "2"},
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "foo:1;bar:2",
+			}),
+		},
 
 		// Slices
 		{
@@ -700,6 +728,34 @@ func TestProcessWith(t *testing.T) {
 			},
 			lookuper: MapLookuper(map[string]string{
 				"FIELD": "foo",
+			}),
+		},
+		{
+			name: "slice/delimiter",
+			input: &struct {
+				Field []string `env:"FIELD,delimiter=;"`
+			}{},
+			exp: &struct {
+				Field []string `env:"FIELD,delimiter=;"`
+			}{
+				Field: []string{"foo", "bar"},
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "foo;bar",
+			}),
+		},
+		{
+			name: "slice/delimiter_wrong",
+			input: &struct {
+				Field []string `env:"FIELD,delimiter=;"`
+			}{},
+			exp: &struct {
+				Field []string `env:"FIELD,delimiter=;"`
+			}{
+				Field: []string{"foo,bar"},
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "foo,bar",
 			}),
 		},
 


### PR DESCRIPTION
## Motivation

Closes #48 

By default when parsing maps or slices, `,` is used as element delimiter.
This PR adds the functionality to define custom delimiter 

## Changes Made

- Added `optDelimiter = "delimiter="` in `options` for reading delimiter's value from the tags.
- Added `delimiter string` in the arguments of `processField`  for incorporating delimiter while processing the fields.

## Usage

```go
type MyStruct struct {
  MyVar map[string]string `env:"MYVAR,delimiter=;"`
}
```

```bash
export MYVAR="a:1;b:2"
# map[string]string{"a":"1", "b":"2"}
```

