### PR TITLE
envconfig: sort strcut fields for reduce memory

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -186,8 +186,8 @@ func PrefixLookuper(prefix string, l Lookuper) Lookuper {
 }
 
 type prefixLookuper struct {
-	prefix string
 	l      Lookuper
+	prefix string
 }
 
 func (p *prefixLookuper) Lookup(key string) (string, bool) {
@@ -222,11 +222,11 @@ type MutatorFunc func(ctx context.Context, k, v string) (string, error)
 type options struct {
 	Default   string
 	Delimiter string
+	Prefix    string
+	Separator string
 	NoInit    bool
 	Overwrite bool
-	Prefix    string
 	Required  bool
-	Separator string
 }
 
 // Process processes the struct using the environment. See ProcessWith for a


### PR DESCRIPTION
envconfig: sort struct fields to reduce memory.

Sort struct fields suggested by fieldalignment. But continue to sort alphabetical order as much as possible.

```console
$ go vet -vettool=$(which fieldalignment) ./...
./envconfig.go:188:21: struct with 32 pointer bytes could be 24
./envconfig.go:222:14: struct of size 80 could be 72
```