### PR TITLE
Change custom unmarshaling order

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -518,16 +518,9 @@ func processAsDecoder(v string, ef reflect.Value) (bool, error) {
 			return imp, err
 		}
 
-		if tu, ok := iface.(encoding.BinaryUnmarshaler); ok {
+		if tu, ok := iface.(encoding.TextUnmarshaler); ok {
 			imp = true
-			if err = tu.UnmarshalBinary([]byte(v)); err == nil {
-				return imp, nil
-			}
-		}
-
-		if tu, ok := iface.(gob.GobDecoder); ok {
-			imp = true
-			if err = tu.GobDecode([]byte(v)); err == nil {
+			if err = tu.UnmarshalText([]byte(v)); err == nil {
 				return imp, nil
 			}
 		}
@@ -539,9 +532,16 @@ func processAsDecoder(v string, ef reflect.Value) (bool, error) {
 			}
 		}
 
-		if tu, ok := iface.(encoding.TextUnmarshaler); ok {
+		if tu, ok := iface.(encoding.BinaryUnmarshaler); ok {
 			imp = true
-			if err = tu.UnmarshalText([]byte(v)); err == nil {
+			if err = tu.UnmarshalBinary([]byte(v)); err == nil {
+				return imp, nil
+			}
+		}
+
+		if tu, ok := iface.(gob.GobDecoder); ok {
+			imp = true
+			if err = tu.GobDecode([]byte(v)); err == nil {
 				return imp, nil
 			}
 		}


### PR DESCRIPTION
Since the input parsed by envconfig is most often configuration written
by humans, it makes sense to test unmarshaling as text before any other
formats. Also JSON should be more common than binary, so this commits
sets the order to:
1. envconfig.Decoder
2. encoding.TextUnmarshaler
3. json.Unmarshaler
4. encoding.BinaryUnmarshaler
5. gob.GobDecoder

and adds tests to very that order. Closes #58.
