### PR TITLE
Only overwrite values when environment variables are set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/sethvargo/go-envconfig
 
 go 1.17
 
-require github.com/google/go-cmp v0.4.1
+require github.com/google/go-cmp v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
-github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
The previous implementation of `overwrite` would always overwrite values in the given struct, even if values existed. While this is the definition of `overwrite`, it unintentionally extended to `default` values as well. So even if a value was explicitly set on a struct, it would be overwritten with the "default" value set in envconfig. This was an unexpected behavior, since defaults should take the lowest precedence.

The new implementation has the following behavior with `overwrite`:

- If the struct field has the zero value and a default is set:

    - If no environment variable is specified, the struct field will be populated with the default value.

    - If an environment variable is specified, the struct field will be populate with the environment variable value.

- If the struct field has a non-zero value and a default is set:

    - If no environment variable is specified, the struct field's existing value will be used (the default is ignored).

    - If an environment variable is specified, the struct field's existing value will be overwritten with the environment variable value.

As part of this change, decoder interfaces are only processed when an environment (or a default) is present.

Closes https://github.com/sethvargo/go-envconfig/issues/61

/cc @raserva @twmb