### PR TITLE
Allow noinit to apply to slices, maps, and unsafe pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,8 +305,8 @@ export APP_MYVAR="foo"
 
 ## Initialization
 
-By default, all pointer fields are initialized (allocated) so they are not
-`nil`. To disable this behavior, use the tag the field as `noinit`:
+By default, all pointers, slices, and maps are initialized (allocated) so they
+are not `nil`. To disable this behavior, use the tag the field as `noinit`:
 
 ```go
 type MyStruct struct {
@@ -332,8 +332,8 @@ type ChildConfig struct {
 }
 ```
 
-The `noinit` tag is only applicable for pointer fields. Putting the tag on a
-non-struct-pointer will return an error.
+The `noinit` tag is only applicable for pointer, slice, and map fields. Putting
+the tag on a different type will return an error.
 
 
 ## Extension

--- a/envconfig.go
+++ b/envconfig.go
@@ -301,7 +301,11 @@ func processWith(ctx context.Context, i interface{}, l Lookuper, parentNoInit bo
 		}
 
 		// NoInit is only permitted on pointers.
-		if opts.NoInit && ef.Kind() != reflect.Ptr {
+		if opts.NoInit &&
+			ef.Kind() != reflect.Ptr &&
+			ef.Kind() != reflect.Slice &&
+			ef.Kind() != reflect.Map &&
+			ef.Kind() != reflect.UnsafePointer {
 			return fmt.Errorf("%s: %w", tf.Name, ErrNoInitNotPtr)
 		}
 		shouldNotInit := opts.NoInit || parentNoInit

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -2226,6 +2227,42 @@ func TestProcessWith(t *testing.T) {
 				"FIELD1": "banana",
 				"FIELD2": "5",
 			}),
+		},
+		{
+			name: "noinit/map",
+			input: &struct {
+				Field map[string]string `env:"FIELD, noinit"`
+			}{},
+			exp: &struct {
+				Field map[string]string `env:"FIELD, noinit"`
+			}{
+				Field: nil,
+			},
+			lookuper: MapLookuper(nil),
+		},
+		{
+			name: "noinit/slice",
+			input: &struct {
+				Field []string `env:"FIELD, noinit"`
+			}{},
+			exp: &struct {
+				Field []string `env:"FIELD, noinit"`
+			}{
+				Field: nil,
+			},
+			lookuper: MapLookuper(nil),
+		},
+		{
+			name: "noinit/unsafe_pointer",
+			input: &struct {
+				Field unsafe.Pointer `env:"FIELD, noinit"`
+			}{},
+			exp: &struct {
+				Field unsafe.Pointer `env:"FIELD, noinit"`
+			}{
+				Field: nil,
+			},
+			lookuper: MapLookuper(nil),
 		},
 		{
 			name: "noinit/error_not_ptr",


### PR DESCRIPTION
Previously, this would throw an error. Fixes GH-82.