### PR TITLE
Only use OsLookuper for default variables

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -515,9 +515,9 @@ func lookup(key string, opts *options, l Lookuper) (string, bool, bool, error) {
 
 		if opts.Default != "" {
 			// Expand the default value. This allows for a default value that maps to
-			// a different variable.
+			// a different environment variable.
 			val = os.Expand(opts.Default, func(i string) string {
-				s, ok := l.Lookup(i)
+				s, ok := OsLookuper().Lookup(i)
 				if ok {
 					return s
 				}


### PR DESCRIPTION
As described in this issue, it's confusing to use anything other than the OsLookuper for default variables. This PR changes the default variable lookuper from using the same one as the actual variable to only using the OsLookuper.