### PR TITLE
feat: Special expansion for env var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ type MyStruct struct {
 
 The value for `Port` will default to the value of `DEFAULT_PORT`.
 
+You can set the value to the original name of the environment variable as
+follows:
+
+```go
+type MyStruct struct {
+  Field string `env:"ENV_VAR,default=$_`
+}
+```
+
+The value of `Field` will default to `"ENV_VAR"`. If there is a prefix, then the
+value will also have the prefix.
+
 It is invalid to have a field as both `required` and `default`.
 
 ### Prefix

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ type MyStruct struct {
 ```
 
 The value of `Field` will default to `"ENV_VAR"`. If there is a prefix, then the
-value will also have the prefix.
+value will also have the prefix. If a value for `_` would be returned upon
+lookup (e.g., there is an environment variable named `_`), that value is given
+precedence.
 
 It is invalid to have a field as both `required` and `default`.
 

--- a/envconfig.go
+++ b/envconfig.go
@@ -517,6 +517,11 @@ func lookup(key string, opts *options, l Lookuper) (string, bool, bool, error) {
 			// Expand the default value. This allows for a default value that maps to
 			// a different variable.
 			val = os.Expand(opts.Default, func(i string) string {
+				s, ok := l.Lookup(i)
+				if ok {
+					return s
+				}
+
 				// special case for the name of the env var itself, including
 				// its prefix
 				if i == "_" {
@@ -526,10 +531,6 @@ func lookup(key string, opts *options, l Lookuper) (string, bool, bool, error) {
 					return key
 				}
 
-				s, ok := l.Lookup(i)
-				if ok {
-					return s
-				}
 				return ""
 			})
 

--- a/envconfig.go
+++ b/envconfig.go
@@ -517,6 +517,15 @@ func lookup(key string, opts *options, l Lookuper) (string, bool, bool, error) {
 			// Expand the default value. This allows for a default value that maps to
 			// a different variable.
 			val = os.Expand(opts.Default, func(i string) string {
+				// special case for the name of the env var itself, including
+				// its prefix
+				if i == "_" {
+					if pl, ok := l.(*prefixLookuper); ok {
+						return pl.prefix + key
+					}
+					return key
+				}
+
 				s, ok := l.Lookup(i)
 				if ok {
 					return s

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -1228,6 +1228,64 @@ func TestProcessWith(t *testing.T) {
 			lookuper: MapLookuper(nil),
 		},
 		{
+			name: "default/expand_env_var_name",
+			input: &struct {
+				Field string `env:"FIELD,default=$_"`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,default=$_"`
+			}{
+				Field: "FIELD",
+			},
+			lookuper: MapLookuper(nil),
+		},
+		{
+			name: "default/expand_underscore_longest_run",
+			input: &struct {
+				Field string `env:"FIELD,default=$_FOO"`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,default=$_FOO"`
+			}{
+				Field: "VALUE",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"_FOO": "VALUE",
+			}),
+		},
+		{
+			name: "default/expand_explicit_env_var_name_with_trailer",
+			input: &struct {
+				Field string `env:"FIELD,default=${_}FOO"`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,default=${_}FOO"`
+			}{
+				Field: "FIELDFOO",
+			},
+			lookuper: MapLookuper(nil),
+		},
+		{
+			name: "default/expand_env_var_name_with_prefix",
+			input: &struct {
+				Struct struct {
+					Field string `env:"FIELD,default=$_"`
+				} `env:",prefix=PREFIX_"`
+			}{},
+			exp: &struct {
+				Struct struct {
+					Field string `env:"FIELD,default=$_"`
+				} `env:",prefix=PREFIX_"`
+			}{
+				Struct: struct {
+					Field string `env:"FIELD,default=$_"`
+				}{
+					Field: "PREFIX_FIELD",
+				},
+			},
+			lookuper: MapLookuper(nil),
+		},
+		{
 			name: "default/slice",
 			input: &struct {
 				Field []string `env:"FIELD,default=foo,bar,baz"`

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -1240,6 +1240,20 @@ func TestProcessWith(t *testing.T) {
 			lookuper: MapLookuper(nil),
 		},
 		{
+			name: "default/expand_override_env_var_name",
+			input: &struct {
+				Field string `env:"FIELD,default=$_"`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,default=$_"`
+			}{
+				Field: "VALUE",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"_": "VALUE",
+			}),
+		},
+		{
 			name: "default/expand_underscore_longest_run",
 			input: &struct {
 				Field string `env:"FIELD,default=$_FOO"`


### PR DESCRIPTION
Let me first say that I love this package.  Thank you so much for your work!

I would really appreciate your having a look at this proposal, and I look forward to discussing it.  Thank you very much in advance for your time.

# What

Provide a special expansion for the name of the environment variable, including its prefix.

I am uncertain about what to name this magical expansion.  ~I opted for `$@`, which is what GNU make uses to reference the target, and shell uses to reference all of the parameters.  It could really be anything that is not normally a valid environment variable name; I am open to suggestions.~  I think `$_` seems like a safe bet.

# Why

It can be advantageous to set the default value to the actual name used, prefix and all.

I will explain a bit about my usecase, and why I think this change would be helpful for other people.

A project I work on, which unfortunately does not use this package, accesses secrets which are set in a secret manager.  The names of those secrets are matched with environment variables.  If a corresponding environment variable for a field is set, its value is used directly instead of accessing the secret manager.  If, however, the corresponding environment variable is not set, then the project accesses the secret manager using the name of the environment variable.

Some new requirements have led to a need to expand on the current implementation, where basically we will have multiple groups of the same set of secrets with different prefixes.  Instead of adding a lot of copypasta, I want to migrate to using this package.  However, there is no way that I could see to have as a default value the actual name of the environment variable that was used at runtime.

It is of course possible to set the default value directly to the same name as the environment variable.  As far as I can tell, though, there is no way to have the prefix, if any, correctly applied.

Here is some sample code which will hopefully illustrate the pain point with prefixes.

```go
// Each field can have a different static default value here.
// The default for ASecret1 != BSecret1 != CSecret1, etc.
type FlatConfig struct {
	ASecret1 string `env:"A_SECRET1,default=sm://A_SECRET1"`
	// ... many different secrets and non-secrets for A

	BSecret1 string `env:"B_SECRET1,default=sm://B_SECRET1"`
	// ... many different fields for B, which mirror those for A

	CSecret1 string `env:"C_SECRET1,default=sm://C_SECRET1"`
	// ... many different fields for C, which mirror those for A and B

	// - Adding in a D or E, which should also mirror A, B, and C, requires lots
	//   of copypasta...
	// - Adding in a new field requires copypasta for each section...
	// - Want to keep this simple and DRY
}

// All fields of SharedConfig get the same default values.
// The default for ConfigA.Secret1 == ConfigB.Secret1 == ConfigC.Secret1, etc.
// It would be nice to add dynamic context to the default so that the default
// for ConfigA.Secret1 != ConfigB.Secret1 != ConfigC.Secret1, etc.
type NestedConfig struct {
	ConfigA SharedConfig `env:",prefix=A_"`
	ConfigB SharedConfig `env:",prefix=B_"`
	ConfigC SharedConfig `env:",prefix=C_"`
	// ... many shared configs with different prefixes
}

type SharedConfig struct {
	Secret1 string `env:"SECRET1,default=sm://needs-to-be-the-resolved-key-but-is-non-contextual"`
	// ... many different fields
}
```

# Other Considerations

There were at least two different implementations considered which could achieve the same desired result (i.e., to set the default value to the properly prefixed key).  Perhaps this behavior is a bug similar to #85?  However, fixing it could potentially break current clients which depend on or expect `k` to not have the prefix, and, as alluded to [in this comment](https://github.com/sethvargo/go-envconfig/issues/85#issuecomment-1553698028), would probably have to wait until 1.0.

## Only on the User End

I tried implementing this with a client-specific keyword for the default value along with a `MutatorFunc`.  However, the `MutatorFunc` [is not passed the actual key that was used](https://github.com/sethvargo/go-envconfig/blob/d0a807644a1685c14de4bf1c31edaf1840bee38f/envconfig.go#L419C25-L419C25) (i.e., the value of parameter `k` is missing the prefix when there is one).  This is why I felt the need for a magic expansion which evaluates to the actual key.

## A New Configuration Option

I considered implementing a new configuration option, `default_to_key` (hopefully with a better name), that takes no value (similar to `required`) and is mutually exclusive with both `required` and `default`.

Something like this:

```go
type MyStruct struct {
  Port int `env:"PORT,default_to_key"`
}
```

While this would be relatively simple to implement, I could not justify opening the floodgates to having a new configuration option for potentially each and every kind of special default, with this just being the first one.

## A Special Keyword

I considered implementing a special keyword for use within `default`.  I had not decided on any particular keyword, but POSIX regular expression character classes will suffice for illustration.

Potentially something like this:

```go
type MyStruct struct {
  Port int `env:"PORT,default=[[:key-goes-here:]]"`
}
```

This would require extra pre-/post-processing of the `default` string in addition to the current shell expansion logic.  I could not justify adding more complexity when leveraging the shell expansion logic is entirely sufficient.

[1]: https://go.dev/play/p/XQt_c4W08D1