### PR TITLE
Change MutatorFunc to be more flexible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/sethvargo/go-envconfig
 
-go 1.17
+go 1.21
 
 require github.com/google/go-cmp v0.5.8


### PR DESCRIPTION
**:warning: BREAKING!** This changes the signature of the `MutatorFunc` to have more information about prior states. It will include the original environment variable names and values, as well as the currently resolved values. Additionally, the mutation chain can now be stopped without returning an error.

- Closes https://github.com/sethvargo/go-envconfig/pull/91