### PR TITLE
Require Go 1.21 or later

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-    - uses: 'actions/checkout@v3'
+    - uses: 'actions/checkout@v4'
 
-    - uses: 'actions/setup-go@v3'
+    - uses: 'actions/setup-go@v4'
       with:
-        go-version: '1.17'
+        go-version: '1.21'
 
     - run: 'make test'

--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ arbitrary lookup functions. It supports pre-setting mutations, which is useful
 for things like converting values to uppercase, trimming whitespace, or looking
 up secrets.
 
-**Note:** Versions prior to v0.2 used a different import path. This README and
-examples are for v0.2+.
-
 ## Usage
 
 Define a struct with fields using the `env` tag:

--- a/envconfig.go
+++ b/envconfig.go
@@ -267,13 +267,13 @@ type options struct {
 
 // Process processes the struct using the environment. See [ProcessWith] for a
 // more customizable version.
-func Process(ctx context.Context, i interface{}) error {
+func Process(ctx context.Context, i any) error {
 	return ProcessWith(ctx, i, OsLookuper())
 }
 
 // ProcessWith processes the given interface with the given lookuper. See the
 // package-level documentation for specific examples and behaviors.
-func ProcessWith(ctx context.Context, i interface{}, l Lookuper, fns ...MutatorFunc) error {
+func ProcessWith(ctx context.Context, i any, l Lookuper, fns ...MutatorFunc) error {
 	return processWith(ctx, i, l, false, fns...)
 }
 
@@ -295,13 +295,13 @@ func ProcessWith(ctx context.Context, i interface{}, l Lookuper, fns ...MutatorF
 //
 // This is effectively the same as calling [ProcessWith] with an empty
 // [MapLookuper].
-func ExtractDefaults(ctx context.Context, i interface{}, fns ...MutatorFunc) error {
+func ExtractDefaults(ctx context.Context, i any, fns ...MutatorFunc) error {
 	return processWith(ctx, i, MapLookuper(nil), false, fns...)
 }
 
 // processWith is a helper that captures whether the parent wanted
 // initialization.
-func processWith(ctx context.Context, i interface{}, l Lookuper, parentNoInit bool, fns ...MutatorFunc) error {
+func processWith(ctx context.Context, i any, l Lookuper, parentNoInit bool, fns ...MutatorFunc) error {
 	if l == nil {
 		return ErrLookuperNil
 	}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -232,8 +232,8 @@ func TestProcessWith(t *testing.T) {
 
 	cases := []struct {
 		name     string
-		input    interface{}
-		exp      interface{}
+		input    any
+		exp      any
 		lookuper Lookuper
 		mutators []MutatorFunc
 		err      error
@@ -2666,8 +2666,8 @@ func TestExtractDefaults(t *testing.T) {
 
 	cases := []struct {
 		name   string
-		input  interface{}
-		exp    interface{}
+		input  any
+		exp    any
 		err    error
 		errMsg string
 	}{

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/sethvargo/go-envconfig
 
 go 1.21
 
-require github.com/google/go-cmp v0.5.8
+require github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
**:warning: Breaking!** The new minimum required Go version is 1.21.