### PR TITLE
Add option in Config to not remove prefix when expanding default values which resolve to other environment variables

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -15,7 +15,7 @@
 // Package envconfig populates struct fields based on environment variable
 // values (or anything that responds to "Lookup"). Structs declare their
 // environment dependencies using the "env" tag with the key being the name of
-// the environment variable, case sensitive.
+// the environment variable, case-sensitive.
 //
 //	type MyStruct struct {
 //	  A string `env:"A"` // resolves A to $A
@@ -264,7 +264,7 @@ type Config struct {
 	// default value is false.
 	DefaultRequired bool
 
-	// Mutators is an optiona list of mutators to apply to lookups.
+	// Mutators is an optional list of mutators to apply to lookups.
 	Mutators []Mutator
 }
 
@@ -839,13 +839,13 @@ func validateEnvName(s string) bool {
 }
 
 // isLetter returns true if the given rune is a letter between a-z,A-Z. This is
-// different than unicode.IsLetter which includes all L character cases.
+// different from unicode.IsLetter which includes all L character cases.
 func isLetter(r rune) bool {
 	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
 }
 
 // isNumber returns true if the given run is a number between 0-9. This is
-// different than unicode.IsNumber in that it only allows 0-9.
+// different from unicode.IsNumber in that it only allows 0-9.
 func isNumber(r rune) bool {
 	return r >= '0' && r <= '9'
 }


### PR DESCRIPTION
Hi there!

The latest v1.0.0 version includes [breaking changes](https://github.com/sethvargo/go-envconfig/releases/tag/v1.0.0), among which the fact that **a prefix will not be taken into account when expanding a default value that resolves to another environment variable**.

I get the [rationale](https://github.com/sethvargo/go-envconfig/issues/85), but find it unfortunate that this was a breaking change and the now default behaviour, as it now makes some code very difficult to reuse and inelegant. Of course, it is possible to implement one's own `Lookuper` in place of using those provided by the library, but in the case of highly dynamic configurations, that also makes for convoluted code.

I suggest making that optional, so that:
1. we do not introduce yet another breaking change, and we don't need to wait for 2.0.0 to merge this (the change is backwards compatible);
2. anyone can choose to profit from this library with or without prefix removal on expansion, or even instantiate `Config` according to the use-case;

This is what this PR implements. Also, I took advantage of this PR to fix a few typos here and there in the doc comments.

Tell me what you think! 😄 