### PR TITLE
Fix README example code comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ examples.
 
     type ServerConfig struct {
       // CacheConfig will process values from $CACHE_REDIS_HOST and
-      // $CACHE_REDIS respectively.
+      // $CACHE_REDIS_USER respectively.
       CacheConfig *RedisConfig `env:", prefix=CACHE_"`
 
       // RateLimitConfig will process values from $RATE_LIMIT_REDIS_HOST and
-      // $RATE_LIMIT_REDIS respectively.
+      // $RATE_LIMIT_REDIS_USER respectively.
       RateLimitConfig *RedisConfig `env:", prefix=RATE_LIMIT_"`
     }
     ```

--- a/envconfig_doc_test.go
+++ b/envconfig_doc_test.go
@@ -134,11 +134,11 @@ func Example_prefix() {
 
 	type ServerConfig struct {
 		// CacheConfig will process values from $CACHE_REDIS_HOST and
-		// $CACHE_REDIS respectively.
+		// $CACHE_REDIS_USER respectively.
 		CacheConfig *RedisConfig `env:", prefix=CACHE_"`
 
 		// RateLimitConfig will process values from $RATE_LIMIT_REDIS_HOST and
-		// $RATE_LIMIT_REDIS respectively.
+		// $RATE_LIMIT_REDIS_USER respectively.
 		RateLimitConfig *RedisConfig `env:", prefix=RATE_LIMIT_"`
 	}
 


### PR DESCRIPTION
## Summary

Fix `prefix` example code comment in README.md

## Links

https://pkg.go.dev/github.com/sethvargo/go-envconfig#example-package-Prefix