### PR TITLE
Handle case where user accidentally uses Process() with a Config when…

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -269,7 +269,8 @@ type Config struct {
 }
 
 // Process decodes the struct using values from environment variables. See
-// [ProcessWith] for a more customizable version.
+// [ProcessWith] for a more customizable version. If *Config is provided for i,
+// [ProcessWith] is called with mus appended.
 func Process(ctx context.Context, i any, mus ...Mutator) error {
 	if v, ok := i.(*Config); ok {
 		v.Mutators = append(v.Mutators, mus...)

--- a/envconfig.go
+++ b/envconfig.go
@@ -270,7 +270,7 @@ type Config struct {
 
 // Process decodes the struct using values from environment variables. See
 // [ProcessWith] for a more customizable version. If *Config is provided for i,
-// [ProcessWith] is called with mus appended.
+// [ProcessWith] is called using the *Config with mus appended.
 func Process(ctx context.Context, i any, mus ...Mutator) error {
 	if v, ok := i.(*Config); ok {
 		v.Mutators = append(v.Mutators, mus...)

--- a/envconfig.go
+++ b/envconfig.go
@@ -264,13 +264,17 @@ type Config struct {
 	// default value is false.
 	DefaultRequired bool
 
-	// Mutators is an optiona list of mutators to apply to lookups.
+	// Mutators is an optional list of mutators to apply to lookups.
 	Mutators []Mutator
 }
 
 // Process decodes the struct using values from environment variables. See
 // [ProcessWith] for a more customizable version.
 func Process(ctx context.Context, i any, mus ...Mutator) error {
+	if v, ok := i.(*Config); ok {
+		v.Mutators = append(v.Mutators, mus...)
+		return ProcessWith(ctx, v)
+	}
 	return ProcessWith(ctx, &Config{
 		Target:   i,
 		Mutators: mus,
@@ -529,7 +533,7 @@ func processWith(ctx context.Context, c *Config) error {
 
 // SplitString splits the given string on the provided rune, unless the rune is
 // escaped by the escape character.
-func splitString(s string, on string, esc string) []string {
+func splitString(s, on, esc string) []string {
 	a := strings.Split(s, on)
 
 	for i := len(a) - 2; i >= 0; i-- {


### PR DESCRIPTION
… they should use ProcessWith() by converting their call to the respective ProcessWith call.

resolves #108 