### PR TITLE
Support Go 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,16 @@ jobs:
   test:
     runs-on: 'ubuntu-latest'
 
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ['stable', 'oldstable']
+
     steps:
       - uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v4
 
       - uses: 'actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491' # ratchet:actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version: ${{ matrix.go-version }}
 
       - run: 'make test'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sethvargo/go-envconfig
 
-go 1.22
+go 1.21
 
 toolchain go1.22.1
 


### PR DESCRIPTION
Fix https://github.com/sethvargo/go-envconfig/issues/111

Also add CI matrix to test on officially supported two Go versions.