### PR TITLE
Relax Go constraint to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/sethvargo/go-envconfig
 
-go 1.22
-
-toolchain go1.22.1
+go 1.20
 
 require github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
- Closes https://github.com/sethvargo/go-envconfig/pull/112
- Closes https://github.com/sethvargo/go-envconfig/issues/111