### PR TITLE
MustProcess: panic if processing fails, return the value

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -285,6 +285,15 @@ func Process(ctx context.Context, i any, mus ...Mutator) error {
 	})
 }
 
+// MustProcess is a helper that calls [Process] and panics if an error is
+// encountered. The input value is returned after processing.
+func MustProcess[T any](ctx context.Context, i T, mus ...Mutator) T {
+	if err := Process(ctx, i, mus...); err != nil {
+		panic(err)
+	}
+	return i
+}
+
 // ProcessWith executes the decoding process using the provided [Config].
 func ProcessWith(ctx context.Context, c *Config) error {
 	if c == nil {

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -3034,3 +3034,25 @@ func TestValidateEnvName(t *testing.T) {
 func ptrTo[T any](i T) *T {
 	return &i
 }
+
+func TestMustProcess_Panic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected a panic")
+		}
+	}()
+	MustProcess(context.Background(), struct {
+		Unset string `env:"UNSET" required:"true"`
+	}{})
+}
+
+func TestMustProcess_Value(t *testing.T) {
+	t.Setenv("SET", "value")
+	s := MustProcess(context.Background(), &struct {
+		Set string `env:"SET"`
+	}{})
+
+	if s.Set != "value" {
+		t.Fatalf("expected %q to be %q", s.Set, "value")
+	}
+}


### PR DESCRIPTION
I originally made this PR to https://github.com/kelseyhightower/envconfig/pull/213 but this looks to be the supported alternative

This adds a generic `MustProcess` method, that panics if processing fails, and returns the spec value.

Example usage:

```
package main

import (
  "log"

  "github.com/sethvargo/go-envconfig"
)

var env = envconfig.MustProcess(context.Background(), &struct{
  Foo string `env:"FOO"`
}{})

func main() {
  log.Println("your FOO is " + env.Foo)
}
```

This lets the env struct be moved to an init-time var, out of `func main`, and retains all the env parsing behavior we've all come to know and love.

The structure of that `var` statement is kind of gross (inline-defining a struct and its empty value, and passing it to the method), if I'm missing some way to make it better, let me know.

Type parameters were required, since `MustProcess(ctx, interface{}) interface{}` loses information about the input type. You could cast back to the type you want, but generics are better IMO, since it lets you do it all in one statement.