### PR TITLE
Introduce raw literal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ examples.
     }
     ```
 
+-   `default.raw` - sets a literal default value for the environment variable
+    if it is not set, without applying any transformations or expansions.
+    This allows for exact values to be used, including special characters. 
+    This option ensures that the exact value provided in the `default.raw` tag is used.
+
+    ```go
+    type MyStruct struct {
+      Token string `env:"TOKEN, default.raw=this^will$be&used|as-is"`
+    }
+    ```
+
+    If the `PORT` environment variable is unset, the field `Port` will be assigned the literal value `expand^makes$no&problems`, without interpreting `$no` or other special characters.
+    
+
 -   `prefix` - sets the prefix to use for looking up environment variable keys
     on child structs and fields. This is useful for shared configurations:
 

--- a/envconfig_doc_test.go
+++ b/envconfig_doc_test.go
@@ -110,7 +110,9 @@ func Example_defaults() {
 
 	type MyStruct struct {
 		Port     int    `env:"PORT, default=8080"`
-		Username string `env:"USERNAME, default=$OTHER_ENV"`
+		Username string `env:"USERNAME, default=$OTHER_ENV"`              // expands to empty
+		ApiKey   string `env:"API_KEY, default=expand^makes$no&problems"` // $no expands to empty without .raw
+		Secret   string `env:"SECRET, default.raw=expand^makes$no&problems|i,hope|!@#$%^&*()_+~{}[]:;,.<>?/|\\"`
 	}
 
 	var s MyStruct
@@ -119,9 +121,15 @@ func Example_defaults() {
 	}
 
 	fmt.Printf("port: %d\n", s.Port)
+	fmt.Printf("username: [%s]\n", s.Username) // for empty brackets
+	fmt.Printf("api-key: %s\n", s.ApiKey)
+	fmt.Printf("secret: %s\n", s.Secret)
 
 	// Output:
 	// port: 8080
+	// username: []
+	// api-key: expand^makes&problems
+	// secret: expand^makes$no&problems|i,hope|!@#$%^&*()_+~{}[]:;,.<>?/|\
 }
 
 func Example_prefix() {


### PR DESCRIPTION
This introduces a new option to handle default values in their raw form. 
When the default.raw option is enabled, the default value is treated exactly as provided, without any modification or expansion. 

Fixes #118.