### PR TITLE
Allow environment variables to start with underscores

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -856,7 +856,7 @@ func validateEnvName(s string) bool {
 	}
 
 	for i, r := range s {
-		if (i == 0 && !isLetter(r)) || (!isLetter(r) && !isNumber(r) && r != '_') {
+		if (i == 0 && !isLetter(r) && r != '_') || (!isLetter(r) && !isNumber(r) && r != '_') {
 			return false
 		}
 	}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -3072,6 +3072,11 @@ func TestValidateEnvName(t *testing.T) {
 			exp:  true,
 		},
 		{
+			name: "underscore_start",
+			in:   "_foo",
+			exp:  true,
+		},
+		{
 			name: "emoji_middle",
 			in:   "FOO🚀",
 			exp:  false,


### PR DESCRIPTION
Fixes https://github.com/sethvargo/go-envconfig/issues/122