### PR TITLE
Introduce the `LookuperFunc` type to simplify the creation of custom implementations of the `Lookuper` interface 

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -108,6 +108,17 @@ type Lookuper interface {
 	Lookup(key string) (string, bool)
 }
 
+var _ Lookuper = (LookuperFunc)(nil)
+
+// LookuperFunc implements the [Lookuper] interface and provides a quick way to
+// create an anonymous function that performs a lookup for a string-based key.
+type LookuperFunc func(key string) (string, bool)
+
+// Lookup implements [Lookuper].
+func (l LookuperFunc) Lookup(key string) (string, bool) {
+	return l(key)
+}
+
 // osLookuper looks up environment configuration from the local environment.
 type osLookuper struct{}
 

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -2930,6 +2930,70 @@ func TestProcessWith(t *testing.T) {
 				"FIELD": "foo bar,zip:zap zoo:zil",
 			}),
 		},
+		// LookuperFunc
+		{
+			name: "lookuperfunc/static",
+			target: &struct {
+				Field1 string `env:"FIELD1"`
+				Field2 string `env:"FIELD2"`
+			}{},
+			lookuper: LookuperFunc(func(key string) (string, bool) {
+				return "foo", true
+			}),
+			exp: &struct {
+				Field1 string `env:"FIELD1"`
+				Field2 string `env:"FIELD2"`
+			}{
+				Field1: "foo",
+				Field2: "foo",
+			},
+		},
+		{
+			name: "lookuperfunc/branching",
+			target: &struct {
+				Field1 string `env:"FIELD1"`
+				Field2 string `env:"FIELD2"`
+			}{},
+			lookuper: LookuperFunc(func(key string) (string, bool) {
+				if key == "FIELD1" {
+					return "foo", true
+				}
+				return "", false
+			}),
+			exp: &struct {
+				Field1 string `env:"FIELD1"`
+				Field2 string `env:"FIELD2"`
+			}{
+				Field1: "foo",
+				Field2: "",
+			},
+		},
+		{
+			name: "lookuperfunc/switching",
+			target: &struct {
+				Field1 string `env:"FIELD1"`
+				Field2 string `env:"FIELD2"`
+				Field3 string `env:"FIELD3"`
+			}{},
+			lookuper: LookuperFunc(func(key string) (string, bool) {
+				switch key {
+				case "FIELD1":
+					return "foo", true
+				case "FIELD2":
+					return "bar", true
+				}
+				return "", false
+			}),
+			exp: &struct {
+				Field1 string `env:"FIELD1"`
+				Field2 string `env:"FIELD2"`
+				Field3 string `env:"FIELD3"`
+			}{
+				Field1: "foo",
+				Field2: "bar",
+				Field3: "",
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This PR introduces a new type, `LookuperFunc`, analogous to the existing `MutatorFunc`, with the intent of providing an easy way to create custom implementations of the `Lookuper` interface directly from an anonymous function. I've also added the related test cases, but let me know if I overlooked anything.