### PR TITLE
Optionally propagate context to Decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,21 @@ the non-nil value. To change this behavior, see
 
 ### Custom Decoders
 
-You can also define your own decoders. See the [godoc][godoc] for more
-information.
+You can also define your own decoders.
+
+```go
+type MyCustomType struct {
+  value string
+}
+
+func (t *MyCustomType) EnvDecode(ctx context.Context, val string) error {
+  resolved := someComplexFunction(val)
+  t.value = resolved
+  return nil
+}
+```
+
+See the [godoc][godoc] for more information.
 
 
 ## Testing


### PR DESCRIPTION
This introduces a new way to define `EnvDecode` to optionally pass in a context. The old way still works, but the context method is preferred. Since it's actually impossible to define the same function with different arguments on the same receiver, there's no possibility of conflict.

Fixes #130 