### PR TITLE
Introduce the `file` tag to enable loading content from a file set as an environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,32 @@ examples.
     }
     ```
 
+-   `file` - read the environment variable value as a file path and load the
+    file's contents as the actual value. This is useful for loading secrets or
+    configuration from files.
+
+    ```go
+    type MyStruct struct {
+      AuthToken string `env:"AUTH_TOKEN_FILE, file"`
+    }
+    ```
+
+    With `AUTH_TOKEN_FILE=./secret.txt` and `secret.txt` containing `my-secret-token`,
+    the `AuthToken` field will be set to `my-secret-token`. Trailing newlines are
+    automatically trimmed from file contents.
+
+    The `file` option can be combined with other options:
+
+    ```go
+    type MyStruct struct {
+      // Required file path
+      AuthToken string `env:"AUTH_TOKEN_FILE, file, required"`
+      
+      // File with default path
+      Config string `env:"CONFIG_FILE, file, default=./config.txt"`
+    }
+    ```
+
 
 ## Decoding
 

--- a/envconfig.go
+++ b/envconfig.go
@@ -56,6 +56,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"strconv"
@@ -70,6 +71,7 @@ const (
 	optDecodeUnset = "decodeunset"
 	optDefault     = "default="
 	optDelimiter   = "delimiter="
+	optFile        = "file"
 	optNoInit      = "noinit"
 	optOverwrite   = "overwrite"
 	optPrefix      = "prefix="
@@ -239,6 +241,7 @@ type options struct {
 	Delimiter   string
 	Prefix      string
 	Separator   string
+	File        bool
 	NoInit      bool
 	Overwrite   bool
 	DecodeUnset bool
@@ -472,7 +475,7 @@ func processWith(ctx context.Context, c *Config) error {
 			// Lookup the value, ignoring an error if the key isn't defined. This is
 			// required for nested structs that don't declare their own `env` keys,
 			// but have internal fields with an `env` defined.
-			val, found, usedDefault, err := lookup(key, required, opts.Default, l)
+			val, found, usedDefault, err := lookup(key, required, opts.Default, opts.File, l)
 			if err != nil && !errors.Is(err, ErrMissingKey) {
 				return fmt.Errorf("%s: %w", tf.Name, err)
 			}
@@ -527,7 +530,7 @@ func processWith(ctx context.Context, c *Config) error {
 			continue
 		}
 
-		val, found, usedDefault, err := lookup(key, required, opts.Default, l)
+		val, found, usedDefault, err := lookup(key, required, opts.Default, opts.File, l)
 		if err != nil {
 			return fmt.Errorf("%s: %w", tf.Name, err)
 		}
@@ -605,6 +608,8 @@ LOOP:
 		switch {
 		case search == optDecodeUnset:
 			opts.DecodeUnset = true
+		case search == optFile:
+			opts.File = true
 		case search == optOverwrite:
 			opts.Overwrite = true
 		case search == optRequired:
@@ -635,7 +640,7 @@ LOOP:
 // first boolean parameter indicates whether the value was found in the
 // lookuper. The second boolean parameter indicates whether the default value
 // was used.
-func lookup(key string, required bool, defaultValue string, l Lookuper) (string, bool, bool, error) {
+func lookup(key string, required bool, defaultValue string, file bool, l Lookuper) (string, bool, bool, error) {
 	if key == "" {
 		// The struct has something like `env:",required"`, which is likely a
 		// mistake. We could try to infer the envvar from the field name, but that
@@ -690,11 +695,46 @@ func lookup(key string, required bool, defaultValue string, l Lookuper) (string,
 			val = strings.ReplaceAll(val, "\u0000", "\\")
 			val = strings.ReplaceAll(val, "\u0008", "$")
 
+			// If file option is set and we have a value from default, read the file content
+			if file && val != "" {
+				fileContent, err := readFileContent(val)
+				if err != nil {
+					return "", false, false, err
+				}
+				val = fileContent
+			}
+
 			return val, false, true, nil
 		}
 	}
 
+	// If file option is set and we found a value, read the file content
+	if file && val != "" {
+		fileContent, err := readFileContent(val)
+		if err != nil {
+			return "", false, false, err
+		}
+		val = fileContent
+	}
+
 	return val, found, false, nil
+}
+
+// readFileContent reads the content from a file path and trims trailing newlines.
+func readFileContent(filePath string) (string, error) {
+	fileContent, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file %q: %w", filePath, err)
+	}
+	defer fileContent.Close()
+	
+	content, err := io.ReadAll(fileContent)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file %q: %w", filePath, err)
+	}
+	
+	// Trim trailing newline which is common in files
+	return strings.TrimRight(string(content), "\r\n"), nil
 }
 
 // processAsDecoder processes the given value as a decoder or custom

--- a/envconfig_doc_test.go
+++ b/envconfig_doc_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 
@@ -386,4 +387,49 @@ func Example_customConfiguration() {
 	// Output:
 	// allowed: map[header1:value1 header2:value2]
 	// rejected: map[header3:value3 header4:value4]
+}
+
+func Example_fileOption() {
+	// This example demonstrates how to use the "file" option to read
+	// configuration values from files. This is particularly useful for
+	// loading secrets or sensitive configuration data.
+
+	// Create temporary test files for the example
+	authFile := "example_auth_token.txt"
+	dbFile := "example_db_password.txt"
+	
+	os.WriteFile(authFile, []byte("secret-auth-token-123"), 0644)
+	os.WriteFile(dbFile, []byte("super-secret-db-password"), 0644)
+	defer os.Remove(authFile)
+	defer os.Remove(dbFile)
+
+	type Config struct {
+		// Read auth token from file path specified in AUTH_TOKEN_FILE
+		AuthToken string `env:"AUTH_TOKEN_FILE,file"`
+		
+		// Read database password from file, required
+		DBPassword string `env:"DB_PASSWORD_FILE,file,required"`
+	}
+
+	var config Config
+	if err := envconfig.ProcessWith(ctx, &envconfig.Config{
+		Target: &config,
+		Lookuper: envconfig.MapLookuper(map[string]string{
+			"AUTH_TOKEN_FILE":   authFile,
+			"DB_PASSWORD_FILE":  dbFile,
+		}),
+	}); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("authtoken: %s\n", config.AuthToken)
+	fmt.Printf("dbpassword: %s\n", config.DBPassword)
+	
+	// Note: In real usage, you would set environment variables like:
+	//   export AUTH_TOKEN_FILE=/path/to/auth-token.txt
+	//   export DB_PASSWORD_FILE=/path/to/db-password.txt
+
+	// Output:
+	// authtoken: secret-auth-token-123
+	// dbpassword: super-secret-db-password
 }

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -3310,4 +3311,194 @@ func TestValidateEnvName(t *testing.T) {
 
 func ptrTo[T any](i T) *T {
 	return &i
+}
+
+func TestFileOption(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		target   any
+		lookuper Lookuper
+		exp      any
+		err      error
+		errMsg   string
+	}{
+		// Basic file reading
+		{
+			name: "file/basic",
+			target: &struct {
+				Field string `env:"FIELD,file"`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,file"`
+			}{
+				Field: "I'm the content",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "test_file_content.txt",
+			}),
+		},
+		
+		// Empty file
+		{
+			name: "file/empty",
+			target: &struct {
+				Field string `env:"FIELD,file"`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,file"`
+			}{
+				Field: "",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "test_empty_file.txt",
+			}),
+		},
+		
+		// Multiline file (should trim trailing newlines)
+		{
+			name: "file/multiline",
+			target: &struct {
+				Field string `env:"FIELD,file"`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,file"`
+			}{
+				Field: "Line 1\nLine 2\nLine 3",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "test_multiline_file.txt",
+			}),
+		},
+		
+		// File not found error
+		{
+			name: "file/not_found",
+			target: &struct {
+				Field string `env:"FIELD,file"`
+			}{},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "nonexistent_file.txt",
+			}),
+			errMsg: "failed to open file",
+		},
+		
+		// File option with required
+		{
+			name: "file/required",
+			target: &struct {
+				Field string `env:"FIELD,file,required"`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,file,required"`
+			}{
+				Field: "I'm the content",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "test_file_content.txt",
+			}),
+		},
+		
+		// File option with required but missing env var
+		{
+			name: "file/required_missing",
+			target: &struct {
+				Field string `env:"FIELD,file,required"`
+			}{},
+			lookuper: MapLookuper(map[string]string{}),
+			errMsg:   "missing required value",
+		},
+		
+		// File option with empty env var (should not try to read file)
+		{
+			name: "file/empty_env_var",
+			target: &struct {
+				Field string `env:"FIELD,file"`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,file"`
+			}{
+				Field: "",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "",
+			}),
+		},
+		
+		// File option with default value (when env var not set)
+		{
+			name: "file/with_default",
+			target: &struct {
+				Field string `env:"FIELD,file,default=test_file_content.txt"`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,file,default=test_file_content.txt"`
+			}{
+				Field: "I'm the content",
+			},
+			lookuper: MapLookuper(map[string]string{}),
+		},
+		
+		// File option with different field types
+		{
+			name: "file/int_field",
+			target: &struct {
+				Field int `env:"FIELD,file"`
+			}{},
+			exp: &struct {
+				Field int `env:"FIELD,file"`
+			}{
+				Field: 42,
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "test_number_file.txt",
+			}),
+		},
+	}
+
+	// Create test files for the tests
+	testFiles := map[string]string{
+		"test_file_content.txt":    "I'm the content",
+		"test_empty_file.txt":      "",
+		"test_multiline_file.txt":  "Line 1\nLine 2\nLine 3",
+		"test_number_file.txt":     "42",
+	}
+	
+	for filename, content := range testFiles {
+		err := os.WriteFile(filename, []byte(content), 0644)
+		if err != nil {
+			t.Fatalf("failed to create test file %s: %v", filename, err)
+		}
+		defer os.Remove(filename)
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			err := ProcessWith(ctx, &Config{
+				Target:   tc.target,
+				Lookuper: tc.lookuper,
+			})
+
+			if tc.errMsg != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q", tc.errMsg)
+				}
+				if !strings.Contains(err.Error(), tc.errMsg) {
+					t.Fatalf("expected error containing %q, got %q", tc.errMsg, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.exp, tc.target); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
 }


### PR DESCRIPTION
`file` - read the environment variable value as a file path and load the file's contents as the actual value. This is useful for loading secrets or configuration from files.

```go
type MyStruct struct {
  AuthToken string `env:"AUTH_TOKEN_FILE, file"`
}
```

With `AUTH_TOKEN_FILE=./secret.txt` and `secret.txt` containing `my-secret-token`, the `AuthToken` field will be set to `my-secret-token`. Trailing newlines are automatically trimmed from file contents.

The `file` option can be combined with other options:

```go
type MyStruct struct {
  // Required file path
  AuthToken string `env:"AUTH_TOKEN_FILE, file, required"`

  // File with default path
  Config string `env:"CONFIG_FILE, file, default=./config.txt"`
}
```