### PR TITLE
Fix non-terminating unwrap walk in prefixLookuper.Unwrap

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -191,7 +191,11 @@ func (p *prefixLookuper) Key(key string) string {
 
 func (p *prefixLookuper) Unwrap() Lookuper {
 	l := p.l
-	for v, ok := l.(unwrappableLookuper); ok; v, ok = l.(unwrappableLookuper) {
+	for {
+		v, ok := l.(unwrappableLookuper)
+		if !ok {
+			break
+		}
 		l = v.Unwrap()
 	}
 	return l

--- a/envconfig.go
+++ b/envconfig.go
@@ -191,7 +191,7 @@ func (p *prefixLookuper) Key(key string) string {
 
 func (p *prefixLookuper) Unwrap() Lookuper {
 	l := p.l
-	for v, ok := l.(unwrappableLookuper); ok; {
+	for v, ok := l.(unwrappableLookuper); ok; v, ok = l.(unwrappableLookuper) {
 		l = v.Unwrap()
 	}
 	return l

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -55,6 +55,25 @@ func (c *CustomDecoderTypeLegacy) EnvDecode(val string) error {
 	return nil
 }
 
+var (
+	_ Lookuper            = (*unwrappableTestLookuper)(nil)
+	_ unwrappableLookuper = (*unwrappableTestLookuper)(nil)
+)
+
+// unwrappableTestLookuper decorates another lookuper and exposes it via
+// Unwrap, like a custom decorating lookuper would.
+type unwrappableTestLookuper struct {
+	l Lookuper
+}
+
+func (u *unwrappableTestLookuper) Lookup(key string) (string, bool) {
+	return u.l.Lookup(key)
+}
+
+func (u *unwrappableTestLookuper) Unwrap() Lookuper {
+	return u.l
+}
+
 // Level mirrors Zap's level marshalling to reproduce an issue for tests.
 type Level int8
 
@@ -1361,6 +1380,28 @@ func TestProcessWith(t *testing.T) {
 				//
 				"DEFAULT": "value",
 			}))),
+		},
+		{
+			name: "default/expand_prefix_unwrappable",
+			target: &struct {
+				Field string `env:"FIELD,default=$DEFAULT"`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,default=$DEFAULT"`
+			}{
+				Field: "value",
+			},
+			lookuper: PrefixLookuper("PREFIX_", &unwrappableTestLookuper{
+				// Ensure the prefix lookuper's unwrap walk terminates when its
+				// child is itself unwrappable, and the default still resolves
+				// against the root MapLookuper:
+				//
+				//     https://github.com/sethvargo/go-envconfig/issues/135
+				//
+				l: MapLookuper(map[string]string{
+					"DEFAULT": "value",
+				}),
+			}),
 		},
 		{
 			name: "default/escaped_doesnt_interpolate",
@@ -3303,6 +3344,63 @@ func TestValidateEnvName(t *testing.T) {
 
 			if got, want := validateEnvName(tc.in), tc.exp; got != want {
 				t.Errorf("expected %q to be %t (got %t)", tc.in, want, got)
+			}
+		})
+	}
+}
+
+func TestPrefixLookuperUnwrap(t *testing.T) {
+	t.Parallel()
+
+	base := MapLookuper(map[string]string{"KEY": "value"})
+
+	cases := []struct {
+		name     string
+		lookuper Lookuper
+	}{
+		{
+			name:     "plain",
+			lookuper: PrefixLookuper("PREFIX_", base),
+		},
+		{
+			name:     "unwrappable",
+			lookuper: PrefixLookuper("PREFIX_", &unwrappableTestLookuper{l: base}),
+		},
+		{
+			name: "unwrappable_nested",
+			lookuper: PrefixLookuper("PREFIX_", &unwrappableTestLookuper{
+				l: &unwrappableTestLookuper{l: base},
+			}),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Unwrap used to spin forever when the child lookuper was itself
+			// unwrappable, so run it under a watchdog to fail fast instead of
+			// hanging the suite on a regression:
+			//
+			//     https://github.com/sethvargo/go-envconfig/issues/135
+			//
+			unwrapped := make(chan Lookuper, 1)
+			go func() {
+				unwrapped <- tc.lookuper.(*prefixLookuper).Unwrap()
+			}()
+
+			select {
+			case got := <-unwrapped:
+				if _, ok := got.(unwrappableLookuper); ok {
+					t.Errorf("expected Unwrap to return the root lookuper, got the still-unwrappable %T", got)
+				}
+				if v, ok := got.Lookup("KEY"); !ok || v != "value" {
+					t.Errorf("expected the root lookuper to resolve KEY (got %q, %t)", v, ok)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("Unwrap did not terminate")
 			}
 		})
 	}


### PR DESCRIPTION
Re-binds the loop variables in `prefixLookuper.Unwrap`'s walk so it terminates when the prefix lookuper's direct child itself implements `Unwrap() Lookuper` (a decorating lookuper). Previously `v, ok` were bound once in the init statement with no post statement, so an unwrappable child made `ok` permanently true and the loop re-derived the same value forever — a CPU-bound hang on the first `default=$VAR` expansion under a prefix. Details and a minimal reproduction are in the linked issue.

Fixes #135

### Tests

- `TestPrefixLookuperUnwrap` exercises the walk directly — plain, unwrappable, and doubly-unwrappable children — under a watchdog, so a regression fails in seconds instead of stalling the suite until `-timeout`.
- A `default/expand_prefix_unwrappable` case in the `TestProcessWith` table extends the existing #85 series (`default/expand_prefix`, `default/expand_prefix_prefix`) with the composition that used to hang, and pins that the default still resolves against the root lookuper.

Without the fix, both new tests fail (`Unwrap did not terminate`; the table case hangs to the test timeout). With it, `make test` (`-race -shuffle=on`) passes.
