### PR TITLE
Chain prefixLookuper.Key through a keyed wrapped lookuper

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -183,11 +183,19 @@ type prefixLookuper struct {
 }
 
 func (p *prefixLookuper) Lookup(key string) (string, bool) {
-	return p.l.Lookup(p.Key(key))
+	return p.l.Lookup(p.prefix + key)
 }
 
+// Key returns the given key with this lookuper's prefix prepended, resolved
+// through the wrapped lookuper's own Key when it implements the keyed
+// extension. This mirrors Lookup, which hands the prefixed key to the wrapped
+// lookuper: the name returned is the name the underlying chain resolves.
 func (p *prefixLookuper) Key(key string) string {
-	return p.prefix + key
+	key = p.prefix + key
+	if keyer, ok := p.l.(keyedLookuper); ok {
+		key = keyer.Key(key)
+	}
+	return key
 }
 
 func (p *prefixLookuper) Unwrap() Lookuper {

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -3288,8 +3288,6 @@ func TestProcessWith(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3475,8 +3473,6 @@ func TestValidateEnvName(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3513,8 +3509,6 @@ func TestPrefixLookuperUnwrap(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -74,6 +74,28 @@ func (u *unwrappableTestLookuper) Unwrap() Lookuper {
 	return u.l
 }
 
+var (
+	_ Lookuper      = (*keyedTestLookuper)(nil)
+	_ keyedLookuper = (*keyedTestLookuper)(nil)
+)
+
+// keyedTestLookuper decorates another lookuper and forwards the keyed
+// extension to it via Key.
+type keyedTestLookuper struct {
+	l Lookuper
+}
+
+func (k *keyedTestLookuper) Lookup(key string) (string, bool) {
+	return k.l.Lookup(key)
+}
+
+func (k *keyedTestLookuper) Key(key string) string {
+	if keyer, ok := k.l.(keyedLookuper); ok {
+		return keyer.Key(key)
+	}
+	return key
+}
+
 // Level mirrors Zap's level marshalling to reproduce an issue for tests.
 type Level int8
 
@@ -3215,6 +3237,20 @@ func TestProcessWith(t *testing.T) {
 				Field3: "",
 			},
 		},
+		{
+			// https://github.com/sethvargo/go-envconfig/issues/137
+			name: "required/missing_nested_prefix_keyed_lookuper",
+			target: &struct {
+				DB struct {
+					Password string `env:"PASSWORD, required"`
+				} `env:", prefix=DB_"`
+			}{},
+			lookuper: &keyedTestLookuper{
+				l: PrefixLookuper("APP_", MapLookuper(nil)),
+			},
+			err:    ErrMissingRequired,
+			errMsg: "missing required value: APP_DB_PASSWORD",
+		},
 	}
 
 	for _, tc := range cases {
@@ -3469,6 +3505,71 @@ func TestPrefixLookuperUnwrap(t *testing.T) {
 				}
 			case <-time.After(5 * time.Second):
 				t.Fatal("Unwrap did not terminate")
+			}
+		})
+	}
+}
+
+func TestPrefixLookuperKey(t *testing.T) {
+	t.Parallel()
+
+	base := MapLookuper(map[string]string{"A_B_KEY": "value"})
+
+	cases := []struct {
+		name     string
+		lookuper Lookuper
+		expKey   string
+		expFound bool
+	}{
+		{
+			name:     "plain",
+			lookuper: PrefixLookuper("PREFIX_", base),
+			expKey:   "PREFIX_KEY",
+			expFound: false,
+		},
+		{
+			name:     "stacked_prefixes_flatten",
+			lookuper: PrefixLookuper("B_", PrefixLookuper("A_", base)),
+			expKey:   "A_B_KEY",
+			expFound: true,
+		},
+		{
+			name: "keyed_wrapped_lookuper",
+			lookuper: PrefixLookuper("B_", &keyedTestLookuper{
+				l: PrefixLookuper("A_", base),
+			}),
+			expKey:   "A_B_KEY",
+			expFound: true,
+		},
+		{
+			// A lookuper that does not implement the keyed extension hides its
+			// name mapping: Key stops at the local prefix, but Lookup still
+			// resolves through the chain.
+			name: "unkeyed_wrapped_lookuper",
+			lookuper: PrefixLookuper("B_", &unwrappableTestLookuper{
+				l: PrefixLookuper("A_", base),
+			}),
+			expKey:   "B_KEY",
+			expFound: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := tc.lookuper.(keyedLookuper).Key("KEY"), tc.expKey; got != want {
+				t.Errorf("expected Key(%q) to be %q (got %q)", "KEY", want, got)
+			}
+
+			v, ok := tc.lookuper.Lookup("KEY")
+			if got, want := ok, tc.expFound; got != want {
+				t.Errorf("expected Lookup(%q) found to be %t (got %t)", "KEY", want, got)
+			}
+			if tc.expFound && v != "value" {
+				t.Errorf("expected Lookup(%q) to resolve %q (got %q)", "KEY", "value", v)
 			}
 		})
 	}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -3251,6 +3251,40 @@ func TestProcessWith(t *testing.T) {
 			err:    ErrMissingRequired,
 			errMsg: "missing required value: APP_DB_PASSWORD",
 		},
+		{
+			// https://github.com/sethvargo/go-envconfig/issues/137
+			//
+			// The issue's second symptom: the mutator resolvedKey must be the
+			// fully-resolved name in the same composition, while originalKey
+			// stays the key as defined on the struct.
+			name: "mutate/resolved_key_nested_prefix_keyed_lookuper",
+			target: &struct {
+				DB struct {
+					Password string `env:"PASSWORD"`
+				} `env:", prefix=DB_"`
+			}{},
+			exp: &struct {
+				DB struct {
+					Password string `env:"PASSWORD"`
+				} `env:", prefix=DB_"`
+			}{
+				DB: struct {
+					Password string `env:"PASSWORD"`
+				}{
+					Password: "oKey:PASSWORD, rKey:APP_DB_PASSWORD",
+				},
+			},
+			lookuper: &keyedTestLookuper{
+				l: PrefixLookuper("APP_", MapLookuper(map[string]string{
+					"APP_DB_PASSWORD": "",
+				})),
+			},
+			mutators: []Mutator{
+				MutatorFunc(func(_ context.Context, oKey, rKey, oVal, cVal string) (string, bool, error) {
+					return fmt.Sprintf("oKey:%s, rKey:%s", oKey, rKey), false, nil
+				}),
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -3589,8 +3589,6 @@ func TestPrefixLookuperKey(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
`prefixLookuper.Key` returned only `p.prefix + key`, ignoring the wrapped
lookuper's own `Key` mapping, while `Lookup` resolves through the whole chain.
With a keyed decorating lookuper under a prefix — the composition `processWith`
builds for every nested `env:",prefix=…"` scope — the name error messages and
mutator `resolvedKey`s report is not the name lookups resolve: a missing
required field inside a nested scope names a variable that setting would not
fix. Details and a minimal reproduction are in the linked issue.

This chains `Key` through a keyed wrapped lookuper, mirroring `Lookup`, and
switches `Lookup` to apply only the local prefix so the chained name mapping
is not applied twice on the resolution path. Stock compositions render
identical names before and after: `prefixLookuper` is the only built-in keyed
lookuper and adjacent prefix lookupers still flatten in the constructor, so
the chained walk engages only when a user-defined keyed lookuper sits under a
prefix. The mutator `resolvedKey` now matches its documented "fully-resolved
environment variable name" in that composition.

Fixes #137

### Tests

- `TestPrefixLookuperKey` exercises `Key`/`Lookup` agreement directly: a plain
  prefix, constructor-flattened stacked prefixes, a keyed decorator between
  prefixes (previously `B_KEY`, now `A_B_KEY`), and an unkeyed decorator
  (unchanged — `Key` cannot see through a lookuper that hides its mapping,
  while `Lookup` still resolves through it; the case also guards the `Lookup`
  rewrite against double-prefixing).
- A `required/missing_nested_prefix_keyed_lookuper` case in the
  `TestProcessWith` table pins the end-to-end message:
  `missing required value: APP_DB_PASSWORD` for a nested `prefix=DB_` scope
  over a keyed decorator wrapping `PrefixLookuper("APP_", …)`.
- A `mutate/resolved_key_nested_prefix_keyed_lookuper` case (sibling of the
  existing `mutate/original_and_resolved_keys`) drives a mutator through the
  same composition and pins the issue's second symptom end-to-end:
  `resolvedKey` arrives fully resolved (`APP_DB_PASSWORD`) while
  `originalKey` stays the key as defined on the struct (`PASSWORD`).

Without the fix, all three new tests fail on the half-resolved name. With it,
`make test` (`-count=1 -race -shuffle=on`) passes.
