### PR TITLE
Modernize for Go 1.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-      - uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v4
+      - uses: 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' # ratchet:actions/checkout@v7
 
-      - uses: 'actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491' # ratchet:actions/setup-go@v5
+      - uses: 'actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e' # ratchet:actions/setup-go@v7
         with:
           go-version-file: 'go.mod'
 

--- a/envconfig.go
+++ b/envconfig.go
@@ -58,6 +58,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -335,14 +336,11 @@ func ProcessWith(ctx context.Context, c *Config) error {
 		c.Lookuper = OsLookuper()
 	}
 
-	// Deep copy the slice and remove any nil mutators.
-	var mus []Mutator
-	for _, m := range c.Mutators {
-		if m != nil {
-			mus = append(mus, m)
-		}
-	}
-	c.Mutators = mus
+	// Clone the slice (so we don't mutate the caller's) and drop any nil
+	// mutators.
+	c.Mutators = slices.DeleteFunc(slices.Clone(c.Mutators), func(m Mutator) bool {
+		return m == nil
+	})
 
 	return processWith(ctx, c)
 }
@@ -357,7 +355,7 @@ func processWith(ctx context.Context, c *Config) error {
 	}
 
 	v := reflect.ValueOf(i)
-	if v.Kind() != reflect.Ptr {
+	if v.Kind() != reflect.Pointer {
 		return ErrNotPtr
 	}
 
@@ -386,7 +384,7 @@ func processWith(ctx context.Context, c *Config) error {
 
 	mutators := c.Mutators
 
-	for i := 0; i < t.NumField(); i++ {
+	for i := range t.NumField() {
 		ef := e.Field(i)
 		tf := t.Field(i)
 		tag := tf.Tag.Get(envTag)
@@ -410,7 +408,7 @@ func processWith(ctx context.Context, c *Config) error {
 
 		// NoInit is only permitted on pointers.
 		if opts.NoInit &&
-			ef.Kind() != reflect.Ptr &&
+			ef.Kind() != reflect.Pointer &&
 			ef.Kind() != reflect.Slice &&
 			ef.Kind() != reflect.Map &&
 			ef.Kind() != reflect.UnsafePointer {
@@ -449,7 +447,7 @@ func processWith(ctx context.Context, c *Config) error {
 
 		// Initialize pointer structs.
 		pointerWasSet := false
-		for ef.Kind() == reflect.Ptr {
+		for ef.Kind() == reflect.Pointer {
 			if ef.IsNil() {
 				if ef.Type().Elem().Kind() != reflect.Struct {
 					// This is a nil pointer to something that isn't a struct, like
@@ -583,7 +581,7 @@ func splitString(s, on, esc string) []string {
 	for i := len(a) - 2; i >= 0; i-- {
 		if strings.HasSuffix(a[i], esc) {
 			a[i] = a[i][:len(a[i])-len(esc)] + on + a[i+1]
-			a = append(a[:i+1], a[i+2:]...)
+			a = slices.Delete(a, i+1, i+2)
 		}
 	}
 	return a
@@ -606,14 +604,20 @@ LOOP:
 		o = strings.TrimLeftFunc(o, unicode.IsSpace)
 		search := strings.ToLower(o)
 
+		// Boolean keyword options ignore surrounding whitespace. Value options
+		// (prefix=, delimiter=, separator=, default=) intentionally preserve any
+		// trailing whitespace as part of their value, so they continue to match on
+		// the left-trimmed-only form.
+		keyword := strings.TrimRightFunc(search, unicode.IsSpace)
+
 		switch {
-		case search == optDecodeUnset:
+		case keyword == optDecodeUnset:
 			opts.DecodeUnset = true
-		case search == optOverwrite:
+		case keyword == optOverwrite:
 			opts.Overwrite = true
-		case search == optRequired:
+		case keyword == optRequired:
 			opts.Required = true
-		case search == optNoInit:
+		case keyword == optNoInit:
 			opts.NoInit = true
 		case strings.HasPrefix(search, optPrefix):
 			opts.Prefix = strings.TrimPrefix(o, optPrefix)
@@ -774,7 +778,7 @@ func processField(ctx context.Context, v string, ef reflect.Value, delimiter, se
 	}
 
 	// Handle pointers and uninitialized pointers.
-	for ef.Type().Kind() == reflect.Ptr {
+	for ef.Type().Kind() == reflect.Pointer {
 		if ef.IsNil() {
 			ef.Set(reflect.New(ef.Type().Elem()))
 		}
@@ -848,11 +852,11 @@ func processField(ctx context.Context, v string, ef reflect.Value, delimiter, se
 		vals := strings.Split(v, delimiter)
 		mp := reflect.MakeMapWithSize(tf, len(vals))
 		for _, val := range vals {
-			pair := strings.SplitN(val, separator, 2)
-			if len(pair) < 2 {
+			mKey, mVal, ok := strings.Cut(val, separator)
+			if !ok {
 				return fmt.Errorf("%s: %w", val, ErrInvalidMapItem)
 			}
-			mKey, mVal := strings.TrimSpace(pair[0]), strings.TrimSpace(pair[1])
+			mKey, mVal = strings.TrimSpace(mKey), strings.TrimSpace(mVal)
 
 			k := reflect.New(tf.Key()).Elem()
 			if err := processField(ctx, mKey, k, delimiter, separator, noInit); err != nil {

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -993,6 +993,22 @@ func TestProcessWith(t *testing.T) {
 			}),
 		},
 		{
+			name: "overwrite/present_trailing_space",
+			target: &struct {
+				Field string `env:"FIELD,overwrite "`
+			}{
+				Field: "hello world",
+			},
+			exp: &struct {
+				Field string `env:"FIELD,overwrite "`
+			}{
+				Field: "foo",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "foo",
+			}),
+		},
+		{
 			name: "overwrite/does_not_overwrite_no_value",
 			target: &struct {
 				Field string `env:"FIELD, overwrite"`
@@ -1161,6 +1177,34 @@ func TestProcessWith(t *testing.T) {
 			}),
 		},
 		{
+			name: "required/present_trailing_space",
+			target: &struct {
+				Field string `env:"FIELD,required "`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,required "`
+			}{
+				Field: "foo",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "foo",
+			}),
+		},
+		{
+			name: "required/present_surrounding_space",
+			target: &struct {
+				Field string `env:"FIELD, required "`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD, required "`
+			}{
+				Field: "foo",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"FIELD": "foo",
+			}),
+		},
+		{
 			name: "required/missing",
 			target: &struct {
 				Field string `env:"FIELD,required"`
@@ -1215,6 +1259,30 @@ func TestProcessWith(t *testing.T) {
 				Field string `env:"FIELD, default=foo"`
 			}{
 				Field: "foo", // uses default
+			},
+			lookuper: MapLookuper(nil),
+		},
+		{
+			name: "default/trailing_space_preserved",
+			target: &struct {
+				Field string `env:"FIELD,default=foo "`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,default=foo "`
+			}{
+				Field: "foo ", // value options keep trailing whitespace
+			},
+			lookuper: MapLookuper(nil),
+		},
+		{
+			name: "default/keyword_value_preserved",
+			target: &struct {
+				Field string `env:"FIELD,default=required "`
+			}{},
+			exp: &struct {
+				Field string `env:"FIELD,default=required "`
+			}{
+				Field: "required ", // value that looks like a keyword stays a value, keeps space
 			},
 			lookuper: MapLookuper(nil),
 		},

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/sethvargo/go-envconfig
 
-go 1.20
+go 1.25
 
-require github.com/google/go-cmp v0.6.0
+require github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=


### PR DESCRIPTION
Modernizes the module to Go 1.25 and cleans up a few things the newer toolchain enables.

## Go version and dependencies

Bumps the `go.mod` directive from `1.20` to `1.25` (bare, no toolchain line) and upgrades `google/go-cmp` from `v0.6.0` to `v0.7.0`. CI already resolves its Go version from `go.mod` via `go-version-file`, so the workflow needed no version edit.

## GitHub Actions

Updates `actions/checkout` (v4 -> v7) and `actions/setup-go` (v5 -> v7), re-pinned to the release SHAs with ratchet.

## Simplifications

All behavior-preserving, enabled by or adjacent to the version bump:

- Integer `range` loop over `reflect` `NumField` (1.22).
- `slices.Delete` in `splitString` (1.21).
- `slices.DeleteFunc` + `slices.Clone` to drop nil mutators, keeping the "don't mutate the caller's slice" contract (1.21).
- `strings.Cut` for map-item splitting.
- `reflect.Pointer` in place of the `reflect.Ptr` alias.

## Bug fix: trailing whitespace on boolean tag options

`keyAndOpts` only left-trimmed each option, so a boolean keyword with trailing whitespace like `env:"FOO, required "` failed with `unknown option`, even though the leading-space form (`env:"FOO, required"`) parsed fine. Boolean keywords (`required`, `overwrite`, `noinit`, `decodeunset`) now match against a both-sides-trimmed form. Value options (`prefix=`, `delimiter=`, `separator=`, `default=`) still match on the left-trimmed-only string, so their trailing whitespace is preserved verbatim. Added table cases covering the boolean fix and a `default=required ` regression guard proving a value that looks like a keyword stays a value and keeps its trailing space.

Verified with `make test` (`-race -shuffle=on`), `go vet`, and `go mod verify`, all green.
