### PR TITLE
Detect recursive struct types in processWith instead of overflowing the stack

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -97,6 +97,7 @@ const (
 	ErrNotStruct          = internalError("input must be a struct")
 	ErrPrefixNotStruct    = internalError("prefix is only valid on struct types")
 	ErrPrivateField       = internalError("cannot parse private fields")
+	ErrRecursiveStruct    = internalError("struct type is recursive")
 	ErrRequiredAndDefault = internalError("field cannot be required and have a default value")
 	ErrUnknownOption      = internalError("unknown option")
 )
@@ -350,11 +351,15 @@ func ProcessWith(ctx context.Context, c *Config) error {
 		return m == nil
 	})
 
-	return processWith(ctx, c)
+	return processWith(ctx, c, make(map[reflect.Type]bool))
 }
 
 // processWith is a helper that retains configuration from the parent structs.
-func processWith(ctx context.Context, c *Config) error {
+// path tracks the struct types on the current descent path: the descent
+// materializes nil struct pointers as it goes, so a type cycle can never
+// terminate on its own and is reported as [ErrRecursiveStruct] instead of
+// recursing without bound.
+func processWith(ctx context.Context, c *Config, path map[reflect.Type]bool) error {
 	i := c.Target
 
 	l := c.Lookuper
@@ -373,6 +378,11 @@ func processWith(ctx context.Context, c *Config) error {
 	}
 
 	t := e.Type()
+	if path[t] {
+		return fmt.Errorf("%s: %w", t, ErrRecursiveStruct)
+	}
+	path[t] = true
+	defer delete(path, t)
 
 	structDelimiter := c.DefaultDelimiter
 	if structDelimiter == "" {
@@ -512,7 +522,7 @@ func processWith(ctx context.Context, c *Config) error {
 				DefaultOverwrite: overwrite,
 				DefaultRequired:  required,
 				Mutators:         mutators,
-			}); err != nil {
+			}, path); err != nil {
 				return fmt.Errorf("%s: %w", tf.Name, err)
 			}
 

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -282,6 +282,44 @@ type MapStruct struct {
 
 type Base64ByteSlice []Base64Bytes
 
+// recursiveNode is self-referential through an untagged field: the descent
+// recurses into exported struct pointers whether or not they carry an env
+// tag.
+type recursiveNode struct {
+	Next *recursiveNode
+}
+
+// recursiveA and recursiveB form a mutually recursive pair.
+type recursiveA struct {
+	B *recursiveB
+}
+
+type recursiveB struct {
+	A *recursiveA
+}
+
+// recursiveTree carries its self-reference in a slice. Collections decode as
+// leaves (element structs are never descended), so the type is not recursive
+// for the descent and must keep decoding.
+type recursiveTree struct {
+	Name     string `env:"NAME"`
+	Children []recursiveTree
+}
+
+// reusedLeaf is used by two sibling fields at once: repeated use of a type
+// that does not cycle must keep decoding.
+type reusedLeaf struct {
+	Value string `env:"VALUE"`
+}
+
+// doublePointerNode's self-reference sits behind a pointer to a pointer: the
+// descent materializes only pointers directly to structs, so a nil
+// **doublePointerNode is skipped rather than materialized.
+type doublePointerNode struct {
+	Value string `env:"VALUE"`
+	Next  **doublePointerNode
+}
+
 func TestProcessWithConfigArgument(t *testing.T) {
 	t.Parallel()
 
@@ -3284,6 +3322,83 @@ func TestProcessWith(t *testing.T) {
 					return fmt.Sprintf("oKey:%s, rKey:%s", oKey, rKey), false, nil
 				}),
 			},
+		},
+		{
+			// https://github.com/sethvargo/go-envconfig/issues/141
+			name:     "recursive/self_referential",
+			target:   &recursiveNode{},
+			lookuper: MapLookuper(nil),
+			err:      ErrRecursiveStruct,
+			errMsg:   "Next: envconfig.recursiveNode: struct type is recursive",
+		},
+		{
+			// https://github.com/sethvargo/go-envconfig/issues/141
+			name:     "recursive/mutually_recursive",
+			target:   &recursiveA{},
+			lookuper: MapLookuper(nil),
+			err:      ErrRecursiveStruct,
+			errMsg:   "B: A: envconfig.recursiveA: struct type is recursive",
+		},
+		{
+			// Collections decode as leaves, so a slice-carried self-reference
+			// is not recursive for the descent and must keep decoding.
+			name:   "recursive/slice_carried_self_reference_ok",
+			target: &recursiveTree{},
+			exp: &recursiveTree{
+				Name: "root",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"NAME": "root",
+			}),
+		},
+		{
+			// A nil pointer-to-pointer is skipped, not materialized: the
+			// descent never re-enters the type, so the shape keeps decoding.
+			name:   "recursive/pointer_to_pointer_nil_ok",
+			target: &doublePointerNode{},
+			exp: &doublePointerNode{
+				Value: "v",
+			},
+			lookuper: MapLookuper(map[string]string{
+				"VALUE": "v",
+			}),
+		},
+		{
+			// A populated pointer-to-pointer chain re-enters the type, so it
+			// is rejected even though its nil tail would have been skipped.
+			// Deliberate: every node in the chain reads the same keys, so a
+			// recursive chain has no distinct meaning per level, and a
+			// deterministic type-level rejection beats a data-dependent one.
+			name: "recursive/pointer_to_pointer_populated",
+			target: func() *doublePointerNode {
+				inner := &doublePointerNode{}
+				return &doublePointerNode{Next: &inner}
+			}(),
+			lookuper: MapLookuper(map[string]string{
+				"VALUE": "v",
+			}),
+			err:    ErrRecursiveStruct,
+			errMsg: "Next: envconfig.doublePointerNode: struct type is recursive",
+		},
+		{
+			// Repeated sibling use of one struct type does not cycle and must
+			// keep decoding: the detection is per descent path, not global.
+			name: "recursive/sibling_reuse_ok",
+			target: &struct {
+				A reusedLeaf `env:", prefix=A_"`
+				B reusedLeaf `env:", prefix=B_"`
+			}{},
+			exp: &struct {
+				A reusedLeaf `env:", prefix=A_"`
+				B reusedLeaf `env:", prefix=B_"`
+			}{
+				A: reusedLeaf{Value: "a"},
+				B: reusedLeaf{Value: "b"},
+			},
+			lookuper: MapLookuper(map[string]string{
+				"A_VALUE": "a",
+				"B_VALUE": "b",
+			}),
 		},
 	}
 


### PR DESCRIPTION
`processWith` descends exported struct and pointer-to-struct fields (tagged
or not), materializing each nil pointer via `reflect.New`, with no cycle
detection — so a self-referential struct type recursed without bound and
crashed the process with a fatal, unrecoverable stack overflow, populated or
not (the walk is not bounded by the instantiated data: it materializes fresh
zero values past a nil tail). Details, verified shape-by-shape behavior, and
a minimal reproduction are in the linked issue.

This tracks the struct types on the current descent path (threaded through
the internal `processWith` recursion; no API change) and returns a new
`ErrRecursiveStruct` sentinel on re-entry, letting the existing field-name
wrapping render the failing path (`Next: main.Node: struct type is
recursive`). A type-level rejection is the useful response here because env
is a flat namespace: every level of a recursive type reads the identical
keys, so its decode has no per-level meaning — the shape is an authoring
error, and the error names the type and the field where the cycle enters,
deterministically.

The tracking is path-scoped — added on entry, removed on exit — so repeated
sibling use of one struct type keeps decoding. Collections are unaffected
(they decode as leaves, so a slice-carried self-reference keeps working), a
struct whose value resolves through a custom decoder is handled before the
recursion, and a cycle the descent never re-enters (an unexported field; a
nil multi-level pointer, which is skipped rather than materialized) is never
rejected. The one deliberate exception is a pre-populated chain threaded
through multi-level pointers (`**T` or deeper) ending at nil multi-level
pointers: it decodes today because the descent skips the nil tail, and is
rejected now because the type re-enters the path — the issue records why a
data-dependent carve-out for it is not worth keeping a shape with no
per-level meaning. Everything else that decodes today is untouched: the
error otherwise fires only on shapes that crash (or, for the inner-nil
multi-pointer variant, panic in the write-back).

Fixes #141

### Tests

Six `TestProcessWith` cases:

- `recursive/self_referential` and `recursive/mutually_recursive` pin the
  error and its rendered path for a direct self-reference through an untagged
  field and a mutually recursive pair.
- `recursive/slice_carried_self_reference_ok` and `recursive/sibling_reuse_ok`
  pin the non-rejections: a slice-carried self-reference and repeated sibling
  use of one struct type both keep decoding.
- `recursive/pointer_to_pointer_nil_ok` and
  `recursive/pointer_to_pointer_populated` pin both sides of the
  multi-level-pointer edge: the nil shape keeps decoding (never re-entered),
  the populated chain is deliberately rejected.

Without the fix, the self-referential and mutually recursive cases crash the
test binary itself with a fatal stack overflow (there is no failure the test
framework could report) and the populated pointer-to-pointer case decodes;
with it, `make test` (`-count=1 -race -shuffle=on`) passes.
