### PR TITLE
Decode structs behind multi-level pointers and reject recursive pointer types

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -97,6 +97,7 @@ const (
 	ErrNotStruct          = internalError("input must be a struct")
 	ErrPrefixNotStruct    = internalError("prefix is only valid on struct types")
 	ErrPrivateField       = internalError("cannot parse private fields")
+	ErrRecursivePointer   = internalError("pointer type is recursive")
 	ErrRecursiveStruct    = internalError("struct type is recursive")
 	ErrRequiredAndDefault = internalError("field cannot be required and have a default value")
 	ErrUnknownOption      = internalError("unknown option")
@@ -449,33 +450,55 @@ func processWith(ctx context.Context, c *Config, path map[reflect.Type]bool) err
 		required := structRequired || opts.Required
 
 		isNilStructPtr := false
+		var nilPtrOrigin reflect.Value
 		setNilStruct := func(v reflect.Value) {
-			origin := e.Field(i)
 			if isNilStructPtr {
-				empty := reflect.New(origin.Type().Elem()).Interface()
+				empty := reflect.New(v.Type().Elem()).Interface()
 
 				// If a struct (after traversal) equals to the empty value, it means
 				// nothing was changed in any sub-fields. With the noinit opt, we skip
 				// setting the empty value to the original struct pointer (keep it nil).
 				if !reflect.DeepEqual(v.Interface(), empty) || !noInit {
-					origin.Set(v)
+					// The origin is the nil pointer the traversal was started from.
+					// It can sit several pointer levels away from the struct, so
+					// rebuild the levels in between before writing back.
+					for v.Type() != nilPtrOrigin.Type() {
+						p := reflect.New(v.Type())
+						p.Elem().Set(v)
+						v = p
+					}
+					nilPtrOrigin.Set(v)
 				}
 			}
 		}
 
 		// Initialize pointer structs.
 		pointerWasSet := false
+		if ef.Kind() == reflect.Pointer && ef.Type().Elem().Kind() == reflect.Pointer {
+			// A named pointer type can dereference to itself (type P *P), directly
+			// or through other named pointer types. No chain of such a type ever
+			// reaches a value to decode into, so dereferencing one below (or
+			// materializing one in processField) would never terminate.
+			if _, ok := nonPointerType(ef.Type()); !ok {
+				return fmt.Errorf("%s: %s: %w", tf.Name, ef.Type(), ErrRecursivePointer)
+			}
+		}
 		for ef.Kind() == reflect.Pointer {
 			if ef.IsNil() {
-				if ef.Type().Elem().Kind() != reflect.Struct {
-					// This is a nil pointer to something that isn't a struct, like
-					// *string. Move along.
+				base, _ := nonPointerType(ef.Type()) // cannot cycle, checked above
+				if base.Kind() != reflect.Struct {
+					// This is a nil pointer chain to something that isn't a struct,
+					// like *string or **string. Move along; processField
+					// materializes those through the field itself.
 					break
 				}
 
 				isNilStructPtr = true
-				// Use an empty struct of the type so we can traverse.
-				ef = reflect.New(ef.Type().Elem()).Elem()
+				nilPtrOrigin = ef
+				// Use an empty struct of the base type so we can traverse; the
+				// write-back in setNilStruct rebuilds any pointer levels between
+				// the origin and the struct.
+				ef = reflect.New(base).Elem()
 			} else {
 				pointerWasSet = true
 				ef = ef.Elem()
@@ -853,6 +876,28 @@ func processAsDecoder(ctx context.Context, v string, ef reflect.Value) (bool, er
 	return imp, err
 }
 
+// nonPointerType returns the first non-pointer type reached by successively
+// dereferencing t, and reports whether one exists. Named pointer types can
+// dereference to themselves (type P *P), directly or through other named
+// pointer types; such a chain never reaches a non-pointer type. The two
+// cursors advance at different speeds, so on a cyclic chain they eventually
+// meet, without allocating a set of visited types.
+func nonPointerType(t reflect.Type) (reflect.Type, bool) {
+	slow, fast := t, t
+	for fast.Kind() == reflect.Pointer {
+		fast = fast.Elem()
+		if fast.Kind() != reflect.Pointer {
+			return fast, true
+		}
+		fast = fast.Elem()
+		slow = slow.Elem()
+		if slow == fast {
+			return nil, false
+		}
+	}
+	return fast, true
+}
+
 func processField(ctx context.Context, v string, ef reflect.Value, delimiter, separator string, noInit bool) error {
 	// If the input value is empty and initialization is skipped, do nothing.
 	if v == "" && noInit {
@@ -860,6 +905,14 @@ func processField(ctx context.Context, v string, ef reflect.Value, delimiter, se
 	}
 
 	// Handle pointers and uninitialized pointers.
+	if ef.Type().Kind() == reflect.Pointer && ef.Type().Elem().Kind() == reflect.Pointer {
+		// Collection elements do not pass through the field-level check in
+		// processWith, so reject recursive pointer types here too, before the
+		// materialization below chases the chain.
+		if _, ok := nonPointerType(ef.Type()); !ok {
+			return fmt.Errorf("%s: %w", ef.Type(), ErrRecursivePointer)
+		}
+	}
 	for ef.Type().Kind() == reflect.Pointer {
 		if ef.IsNil() {
 			ef.Set(reflect.New(ef.Type().Elem()))

--- a/envconfig.go
+++ b/envconfig.go
@@ -450,7 +450,7 @@ func processWith(ctx context.Context, c *Config, path map[reflect.Type]bool) err
 		required := structRequired || opts.Required
 
 		isNilStructPtr := false
-		var nilPtrOrigin reflect.Value
+		var nilPtrOrigin, nilPtrChain reflect.Value
 		setNilStruct := func(v reflect.Value) {
 			if isNilStructPtr {
 				empty := reflect.New(v.Type().Elem()).Interface()
@@ -459,15 +459,7 @@ func processWith(ctx context.Context, c *Config, path map[reflect.Type]bool) err
 				// nothing was changed in any sub-fields. With the noinit opt, we skip
 				// setting the empty value to the original struct pointer (keep it nil).
 				if !reflect.DeepEqual(v.Interface(), empty) || !noInit {
-					// The origin is the nil pointer the traversal was started from.
-					// It can sit several pointer levels away from the struct, so
-					// rebuild the levels in between before writing back.
-					for v.Type() != nilPtrOrigin.Type() {
-						p := reflect.New(v.Type())
-						p.Elem().Set(v)
-						v = p
-					}
-					nilPtrOrigin.Set(v)
+					nilPtrOrigin.Set(nilPtrChain)
 				}
 			}
 		}
@@ -495,10 +487,18 @@ func processWith(ctx context.Context, c *Config, path map[reflect.Type]bool) err
 
 				isNilStructPtr = true
 				nilPtrOrigin = ef
-				// Use an empty struct of the base type so we can traverse; the
-				// write-back in setNilStruct rebuilds any pointer levels between
-				// the origin and the struct.
-				ef = reflect.New(base).Elem()
+				// Materialize a detached pointer chain that keeps the field's
+				// declared type at every level, initializing each cell from its
+				// own element type the way processField's pointer loop does, and
+				// traverse the empty struct at its end. setNilStruct attaches
+				// the whole chain to the origin with a single Set.
+				nilPtrChain = reflect.New(ef.Type().Elem())
+				cell := nilPtrChain.Elem()
+				for cell.Kind() == reflect.Pointer {
+					cell.Set(reflect.New(cell.Type().Elem()))
+					cell = cell.Elem()
+				}
+				ef = cell
 			} else {
 				pointerWasSet = true
 				ef = ef.Elem()

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -312,13 +312,29 @@ type reusedLeaf struct {
 	Value string `env:"VALUE"`
 }
 
-// doublePointerNode's self-reference sits behind a pointer to a pointer: the
-// descent materializes only pointers directly to structs, so a nil
-// **doublePointerNode is skipped rather than materialized.
+// doublePointerNode's self-reference sits behind a pointer to a pointer:
+// materialization reaches the struct at the end of a pointer chain of any
+// depth, so the type re-enters the descent path whether the chain is nil or
+// populated.
 type doublePointerNode struct {
 	Value string `env:"VALUE"`
 	Next  **doublePointerNode
 }
+
+// pointerChainLeaf sits at the end of the multi-level pointer chains in the
+// multi_pointer tests.
+type pointerChainLeaf struct {
+	Value string `env:"VALUE"`
+}
+
+// selfPointer dereferences to itself: no chain of it ever reaches a
+// non-pointer type to decode into.
+type selfPointer *selfPointer
+
+// mutualPointerA and mutualPointerB dereference to each other.
+type mutualPointerA *mutualPointerB
+
+type mutualPointerB *mutualPointerA
 
 func TestProcessWithConfigArgument(t *testing.T) {
 	t.Parallel()
@@ -3352,16 +3368,17 @@ func TestProcessWith(t *testing.T) {
 			}),
 		},
 		{
-			// A nil pointer-to-pointer is skipped, not materialized: the
-			// descent never re-enters the type, so the shape keeps decoding.
-			name:   "recursive/pointer_to_pointer_nil_ok",
+			// Materialization reaches the struct at the end of a pointer chain
+			// of any depth, so a recursive type behind a nil pointer-to-pointer
+			// re-enters the descent path exactly like the populated chain
+			// below: the rejection is type-level, not data-dependent.
+			name:   "recursive/pointer_to_pointer_nil",
 			target: &doublePointerNode{},
-			exp: &doublePointerNode{
-				Value: "v",
-			},
 			lookuper: MapLookuper(map[string]string{
 				"VALUE": "v",
 			}),
+			err:    ErrRecursiveStruct,
+			errMsg: "Next: envconfig.doublePointerNode: struct type is recursive",
 		},
 		{
 			// A populated pointer-to-pointer chain re-enters the type, so it
@@ -3399,6 +3416,203 @@ func TestProcessWith(t *testing.T) {
 				"A_VALUE": "a",
 				"B_VALUE": "b",
 			}),
+		},
+
+		// Multi-level pointers
+		{
+			// https://github.com/sethvargo/go-envconfig/issues/143
+			// A nil pointer chain of any depth ending at a struct is
+			// materialized and written back, wired through every level.
+			name: "multi_pointer/materializes_nil_chain",
+			target: &struct {
+				P **pointerChainLeaf
+			}{},
+			exp: &struct {
+				P **pointerChainLeaf
+			}{
+				P: ptrTo(ptrTo(pointerChainLeaf{Value: "v"})),
+			},
+			lookuper: MapLookuper(map[string]string{
+				"VALUE": "v",
+			}),
+		},
+		{
+			name: "multi_pointer/materializes_nil_chain_deep",
+			target: &struct {
+				P ***pointerChainLeaf
+			}{},
+			exp: &struct {
+				P ***pointerChainLeaf
+			}{
+				P: ptrTo(ptrTo(ptrTo(pointerChainLeaf{Value: "v"}))),
+			},
+			lookuper: MapLookuper(map[string]string{
+				"VALUE": "v",
+			}),
+		},
+		{
+			// Without noinit, a nil chain is initialized even when nothing was
+			// set, matching the single-level behavior.
+			name: "multi_pointer/initializes_empty_chain",
+			target: &struct {
+				P **pointerChainLeaf
+			}{},
+			exp: &struct {
+				P **pointerChainLeaf
+			}{
+				P: ptrTo(ptrTo(pointerChainLeaf{})),
+			},
+			lookuper: MapLookuper(nil),
+		},
+		{
+			// https://github.com/sethvargo/go-envconfig/issues/143
+			// A nil pointer partway down a populated chain: the write-back
+			// goes to that pointer, not to the field, which used to panic in
+			// reflect.Set.
+			name: "multi_pointer/inner_nil_write_back",
+			target: &struct {
+				P **pointerChainLeaf
+			}{
+				P: ptrTo((*pointerChainLeaf)(nil)),
+			},
+			exp: &struct {
+				P **pointerChainLeaf
+			}{
+				P: ptrTo(ptrTo(pointerChainLeaf{Value: "v"})),
+			},
+			lookuper: MapLookuper(map[string]string{
+				"VALUE": "v",
+			}),
+		},
+		{
+			// noinit holds across the whole chain: nothing was set, so the
+			// field stays nil at every level.
+			name: "multi_pointer/noinit_keeps_chain_nil",
+			target: &struct {
+				P **pointerChainLeaf `env:",noinit"`
+			}{},
+			exp: &struct {
+				P **pointerChainLeaf `env:",noinit"`
+			}{},
+			lookuper: MapLookuper(nil),
+		},
+		{
+			// noinit with a populated outer pointer and nothing set: the nil
+			// inner pointer is left alone.
+			name: "multi_pointer/noinit_keeps_inner_nil",
+			target: &struct {
+				P **pointerChainLeaf `env:",noinit"`
+			}{
+				P: ptrTo((*pointerChainLeaf)(nil)),
+			},
+			exp: &struct {
+				P **pointerChainLeaf `env:",noinit"`
+			}{
+				P: ptrTo((*pointerChainLeaf)(nil)),
+			},
+			lookuper: MapLookuper(nil),
+		},
+		{
+			// A fully populated chain decodes in place, no write-back needed.
+			name: "multi_pointer/populated_chain_in_place",
+			target: &struct {
+				P **pointerChainLeaf
+			}{
+				P: ptrTo(ptrTo(pointerChainLeaf{})),
+			},
+			exp: &struct {
+				P **pointerChainLeaf
+			}{
+				P: ptrTo(ptrTo(pointerChainLeaf{Value: "v"})),
+			},
+			lookuper: MapLookuper(map[string]string{
+				"VALUE": "v",
+			}),
+		},
+		{
+			// A prefix descends through any pointer depth; it used to be
+			// rejected with ErrPrefixNotStruct beyond one level.
+			name: "multi_pointer/prefix_descends_chain",
+			target: &struct {
+				Sub **pointerChainLeaf `env:", prefix=SUB_"`
+			}{},
+			exp: &struct {
+				Sub **pointerChainLeaf `env:", prefix=SUB_"`
+			}{
+				Sub: ptrTo(ptrTo(pointerChainLeaf{Value: "v"})),
+			},
+			lookuper: MapLookuper(map[string]string{
+				"SUB_VALUE": "v",
+			}),
+		},
+
+		// Recursive pointer types
+		{
+			// A self-referential pointer type never reaches a value to decode
+			// into, so it is rejected up front, nil or not. A non-nil chain
+			// used to spin the dereference loop forever.
+			name: "recursive_pointer/nil",
+			target: &struct {
+				Link selfPointer
+			}{},
+			lookuper: MapLookuper(nil),
+			err:      ErrRecursivePointer,
+			errMsg:   "Link: envconfig.selfPointer: pointer type is recursive",
+		},
+		{
+			// https://github.com/sethvargo/go-envconfig/issues/143
+			name: "recursive_pointer/self_pointing_value",
+			target: func() any {
+				var p selfPointer
+				p = &p
+				return &struct {
+					Link selfPointer
+				}{
+					Link: p,
+				}
+			}(),
+			lookuper: MapLookuper(nil),
+			err:      ErrRecursivePointer,
+			errMsg:   "Link: envconfig.selfPointer: pointer type is recursive",
+		},
+		{
+			// Mutually recursive pointer types are the same cycle one step
+			// apart.
+			name: "recursive_pointer/mutual",
+			target: &struct {
+				Link mutualPointerA
+			}{},
+			lookuper: MapLookuper(nil),
+			err:      ErrRecursivePointer,
+			errMsg:   "Link: envconfig.mutualPointerA: pointer type is recursive",
+		},
+		{
+			// A tagged nil field of a recursive pointer type used to reach the
+			// pointer materialization in processField and allocate without
+			// bound.
+			name: "recursive_pointer/tagged_nil",
+			target: &struct {
+				Link selfPointer `env:"LINK"`
+			}{},
+			lookuper: MapLookuper(map[string]string{
+				"LINK": "x",
+			}),
+			err:    ErrRecursivePointer,
+			errMsg: "Link: envconfig.selfPointer: pointer type is recursive",
+		},
+		{
+			// Collection elements decode through processField and its pointer
+			// materialization directly, without passing the field-level check,
+			// so the element type is rejected there.
+			name: "recursive_pointer/slice_element",
+			target: &struct {
+				Links []selfPointer `env:"LINKS"`
+			}{},
+			lookuper: MapLookuper(map[string]string{
+				"LINKS": "a",
+			}),
+			err:    ErrRecursivePointer,
+			errMsg: "envconfig.selfPointer: pointer type is recursive",
 		},
 	}
 

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -327,6 +327,13 @@ type pointerChainLeaf struct {
 	Value string `env:"VALUE"`
 }
 
+// namedLeafPointer and namedDoubleLeafPointer are named pointer types in the
+// chain: the write-back must preserve the field's declared type at every
+// level rather than rebuilding the chain from unnamed pointer types.
+type namedLeafPointer *pointerChainLeaf
+
+type namedDoubleLeafPointer **pointerChainLeaf
+
 // selfPointer dereferences to itself: no chain of it ever reaches a
 // non-pointer type to decode into.
 type selfPointer *selfPointer
@@ -3543,6 +3550,53 @@ func TestProcessWith(t *testing.T) {
 			},
 			lookuper: MapLookuper(map[string]string{
 				"SUB_VALUE": "v",
+			}),
+		},
+		{
+			// A named pointer type as the field type: the attached value must
+			// carry the declared type, which only assignability permits (an
+			// identity-based rebuild of the chain never terminates).
+			name: "multi_pointer/named_pointer",
+			target: &struct {
+				P namedLeafPointer
+			}{},
+			exp: &struct {
+				P namedLeafPointer
+			}{
+				P: namedLeafPointer(ptrTo(pointerChainLeaf{Value: "v"})),
+			},
+			lookuper: MapLookuper(map[string]string{
+				"VALUE": "v",
+			}),
+		},
+		{
+			// A named pointer type in the middle of the chain.
+			name: "multi_pointer/pointer_to_named_pointer",
+			target: &struct {
+				P *namedLeafPointer
+			}{},
+			exp: &struct {
+				P *namedLeafPointer
+			}{
+				P: ptrTo(namedLeafPointer(ptrTo(pointerChainLeaf{Value: "v"}))),
+			},
+			lookuper: MapLookuper(map[string]string{
+				"VALUE": "v",
+			}),
+		},
+		{
+			// A named pointer-to-pointer type as the field type.
+			name: "multi_pointer/named_double_pointer",
+			target: &struct {
+				P namedDoubleLeafPointer
+			}{},
+			exp: &struct {
+				P namedDoubleLeafPointer
+			}{
+				P: namedDoubleLeafPointer(ptrTo(ptrTo(pointerChainLeaf{Value: "v"}))),
+			},
+			lookuper: MapLookuper(map[string]string{
+				"VALUE": "v",
 			}),
 		},
 


### PR DESCRIPTION
The per-field pointer handling in `processWith` was designed for exactly one
pointer level, which left `**T`-and-deeper fields half-broken and
data-dependent: a struct materialized beneath a populated outer pointer
panicked in the write-back (`reflect.Set: value of type *T is not assignable
to type **T`), a fully nil chain was silently skipped while its single-level
neighbor decoded, the same field with a prefix failed with
`ErrPrefixNotStruct`, with `noinit` it failed with `missing key`, and a fully
populated chain decoded fine. Separately, nothing guarded the two loops that
walk pointer chains, so a self-referential pointer type (`type P *P`) either
pinned a core forever (non-nil value, dereference loop) or allocated without
bound until `fatal error: out of memory` (tagged nil value or collection
element, `processField` materialization). Details and minimal reproductions
are in the linked issue.

This makes pointer depth irrelevant to decoding semantics. The dereference
loop materializes the struct at the end of a nil pointer chain of any depth
(previously only depth one), and the write-back targets the nil pointer the
traversal started from instead of the field root, rebuilding any pointer
levels in between before the single `Set`. `**Inner` therefore behaves
exactly like `*Inner` for initialization, `noinit` (the emptiness check now
compares at the struct type, so a chain stays nil when nothing was set),
prefixes, and write-back; populated chains keep decoding in place with no
write-back, as today.

Pointer types whose dereference chain never reaches a non-pointer type
(`type P *P`, mutually recursive pairs) are rejected up front with a new
`ErrRecursivePointer` sentinel, at the field level and again in
`processField`, which collection elements reach without passing the field
check. This is the `ErrRecursiveStruct` reasoning one layer down: no chain
of such a type ever reaches a value to decode into, so the shape is an
authoring error and a deterministic type-level rejection beats a hang. The
existing field-name wrapping renders the failing path
(`Link: main.P: pointer type is recursive`). Ordinary pointer fields pay two
`Kind` calls; the cycle walk (two type cursors advancing at different
speeds, no allocation) runs only for pointer-to-pointer shapes.

Two deliberate behavior changes, both toward type-level determinism:

- A recursive struct type behind a **nil** pointer-to-pointer was skipped
  and decoded; materialization now reaches it, so it is rejected with
  `ErrRecursiveStruct` exactly like its populated counterpart
  (`recursive/pointer_to_pointer_nil`, previously
  `recursive/pointer_to_pointer_nil_ok`). #142 rejected the populated chain
  on the grounds that a type-level rejection beats a data-dependent one;
  this removes the remaining data-dependence.
- Untagged nil fields of recursive pointer types were skipped; they now
  fail fast with `ErrRecursivePointer`, since every other value of such a
  type hangs or OOMs the process.

Fixes #143

### Tests

Fourteen `TestProcessWith` cases. Thirteen fail on the unfixed code (two by
`reflect.Set` panic, one by a hard hang, two by out-of-memory, the rest by
wrong results or wrong errors); `multi_pointer/populated_chain_in_place`
passes before and after, pinning that the working path stays untouched.

- `multi_pointer/materializes_nil_chain`, `materializes_nil_chain_deep`, and
  `initializes_empty_chain` pin materialization and write-back through `**T`
  and `***T`, with and without values set.
- `multi_pointer/inner_nil_write_back` pins the panic shape: a nil pointer
  partway down a populated chain, written back to that pointer rather than
  the field.
- `multi_pointer/noinit_keeps_chain_nil` and `noinit_keeps_inner_nil` pin
  `noinit` across the chain: nothing set leaves every level (and only the
  nil suffix) untouched.
- `multi_pointer/prefix_descends_chain` pins that a prefix works at any
  pointer depth (previously `ErrPrefixNotStruct`).
- `recursive_pointer/nil`, `self_pointing_value`, `mutual`, `tagged_nil`,
  and `slice_element` pin the new rejection at both check sites and its
  rendered path, covering the hang (self-pointing value) and both
  out-of-memory shapes (tagged nil field, slice element).
- `recursive/pointer_to_pointer_nil` pins the flipped #142 edge: the nil
  chain of a recursive struct type is now rejected like the populated one.

With the fix, `make test` (`-count=1 -race -shuffle=on -timeout=10m`) passes,
`gofmt -l` is clean, and the `modernize` analyzer reports nothing.
